### PR TITLE
Replace spaces with tabs in main source files

### DIFF
--- a/src/ifplugd.action
+++ b/src/ifplugd.action
@@ -7,52 +7,52 @@
 PROFILE_FILE="$STATE_DIR/ifplugd_$1.profile"
 
 case "$2" in
-  up)
-    # Look for a dhcp based profile to try first
-    # dhcp can actually outright fail, whereas
-    # it's difficult to tell if static succeeded
-    # Also check profile is same iface and is right connection
-    echo "up"
-    declare -a preferred_profiles
-    declare -a dhcp_profiles
-    declare -a static_profiles
-    while read -r profile; do
-        (
-          echo "Reading profile '$profile'"
-          source "$PROFILE_DIR/$profile"
-          [[ "$Interface" == "$1" && "$Connection" == "ethernet" ]] || continue
-          is_yes "${AutoWired:-no}" && exit 1 # user preferred AUTO profile
-          [[ "$IP" == "dhcp" ]] && exit 2 # dhcp profile
-          exit 3 # static profile
-        )
-        case $? in
-          1) preferred_profiles+=("$profile");;
-          2) dhcp_profiles+=("$profile");;
-          3) static_profiles+=("$profile");;
-        esac
-    done < <(list_profiles)
-    if [[ ${#preferred_profiles[@]} > 1 ]]; then
-        echo "AutoWired flag for '$1' set in more than one profile (${preferred_profiles[*]})"
-    fi
-    for profile in "${preferred_profiles[@]}" "${dhcp_profiles[@]}" "${static_profiles[@]}"; do
-        if ForceConnect=yes "$SUBR_DIR/network" start "$profile"; then
-            mkdir -p "$(dirname "$PROFILE_FILE")"
-            printf "%s" "$profile" > "$PROFILE_FILE"
-            exit 0
-        fi
-    done
-  ;;
-  down)
-    if [[ -e "$PROFILE_FILE" ]]; then
-        if ForceConnect=yes "$SUBR_DIR/network" stop "$(< "$PROFILE_FILE")"; then
-            rm -f "$PROFILE_FILE"
-            exit 0
-        fi
-    fi
-  ;;
-  *)
-    echo "Wrong arguments" > /dev/stderr
-  ;;
+	up)
+		# Look for a dhcp based profile to try first
+		# dhcp can actually outright fail, whereas
+		# it's difficult to tell if static succeeded
+		# Also check profile is same iface and is right connection
+		echo "up"
+		declare -a preferred_profiles
+		declare -a dhcp_profiles
+		declare -a static_profiles
+		while read -r profile; do
+			(
+				echo "Reading profile '$profile'"
+				source "$PROFILE_DIR/$profile"
+				[[ "$Interface" == "$1" && "$Connection" == "ethernet" ]] || continue
+				is_yes "${AutoWired:-no}" && exit 1 # user preferred AUTO profile
+				[[ "$IP" == "dhcp" ]] && exit 2 # dhcp profile
+				exit 3 # static profile
+			)
+			case $? in
+				1) preferred_profiles+=("$profile");;
+				2) dhcp_profiles+=("$profile");;
+				3) static_profiles+=("$profile");;
+			esac
+		done < <(list_profiles)
+		if [[ ${#preferred_profiles[@]} > 1 ]]; then
+			echo "AutoWired flag for '$1' set in more than one profile (${preferred_profiles[*]})"
+		fi
+		for profile in "${preferred_profiles[@]}" "${dhcp_profiles[@]}" "${static_profiles[@]}"; do
+			if ForceConnect=yes "$SUBR_DIR/network" start "$profile"; then
+				mkdir -p "$(dirname "$PROFILE_FILE")"
+				printf "%s" "$profile" > "$PROFILE_FILE"
+				exit 0
+			fi
+		done
+	;;
+	down)
+		if [[ -e "$PROFILE_FILE" ]]; then
+			if ForceConnect=yes "$SUBR_DIR/network" stop "$(< "$PROFILE_FILE")"; then
+				rm -f "$PROFILE_FILE"
+				exit 0
+			fi
+		fi
+	;;
+	*)
+		echo "Wrong arguments" > /dev/stderr
+	;;
 esac
 
 exit 1

--- a/src/netctl
+++ b/src/netctl
@@ -6,7 +6,7 @@ NETCTL_VERSION=notpackaged
 
 
 usage() {
-    cat << END
+	cat << END
 Usage: netctl {COMMAND} [PROFILE]
               [--help|--version]
 
@@ -27,128 +27,127 @@ END
 }
 
 list() {
-    local indicators=( '*' ' ' )
-    list_profiles | while read -r Profile; do
-        systemctl is-active --quiet "netctl@$Profile.service" &> /dev/null
-        # Make the return variable boolean
-        [[ $? -eq 0 ]]; printf '%s %s\n' "${indicators[$?]}" "$Profile"
-    done
+	local indicators=( '*' ' ' )
+	list_profiles | while read -r Profile; do
+		systemctl is-active --quiet "netctl@$Profile.service" &> /dev/null
+		# Make the return variable boolean
+		[[ $? -eq 0 ]]; printf '%s %s\n' "${indicators[$?]}" "$Profile"
+	done
 }
 
 store() {
-    mkdir -p "$(dirname "$STATE_FILE")"
-    systemctl list-units --type=service --full --no-legend --no-pager | \
-      cut -d\  -f1 | grep "^netctl@" > "$STATE_FILE"
+	mkdir -p "$(dirname "$STATE_FILE")"
+	systemctl list-units --type=service --full --no-legend --no-pager | \
+		cut -d\  -f1 | grep "^netctl@" > "$STATE_FILE"
 }
 
 restore() {
-    if [[ ! -r $STATE_FILE ]]; then
-        exit_error "Could not read state file '$STATE_FILE'"
-    elif [[ ! -s $STATE_FILE ]]; then
-        report_debug "No profiles to restore in state file '$STATE_FILE'"
-    else
-        mapfile -t Units < "$STATE_FILE"
-        do_debug systemctl start "${Units[@]}"
-    fi
+	if [[ ! -r $STATE_FILE ]]; then
+		exit_error "Could not read state file '$STATE_FILE'"
+	elif [[ ! -s $STATE_FILE ]]; then
+		report_debug "No profiles to restore in state file '$STATE_FILE'"
+	else
+		mapfile -t Units < "$STATE_FILE"
+		do_debug systemctl start "${Units[@]}"
+	fi
 }
 
 stop_all() {
-    # We cannot pipe to mapfile, as the end of a pipe is inside a subshell
-    mapfile -t Profiles < <(list_profiles)
-    [[ $Profiles ]] && do_debug systemctl stop "${Profiles[@]/#/netctl@}" 2> \
-      >(grep -Fv "not loaded" >&2)
+	# We cannot pipe to mapfile, as the end of a pipe is inside a subshell
+	mapfile -t Profiles < <(list_profiles)
+	[[ $Profiles ]] && do_debug systemctl stop "${Profiles[@]/#/netctl@}" 2> \
+		>(grep -Fv "not loaded" >&2)
 }
 
 switch_to() {
-    cd "$PROFILE_DIR"
-    if [[ ! -r $1 ]]; then
-        exit_error "Profile '$1' does not exist or is not readable"
-    fi
-    # We assume interface names are not quoted
-    # Using read removes leading whitespace
-    read InterfaceLine < \
-      <(grep -om1 "^[[:space:]]*Interface=[[:alnum:]:._-]\+" "$1")
-    if [[ -z $InterfaceLine ]]; then
-        exit_error "Profile '$1' does not specify an interface"
-    fi
-    mapfile -t AllProfiles < <(list_profiles)
-    mapfile -t Profiles < <(grep -Fl "$InterfaceLine" "${AllProfiles[@]}")
-    [[ $Profiles ]] && do_debug systemctl stop "${Profiles[@]/#/netctl@}" 2> \
-      >(grep -Fv "not loaded" >&2)
-    do_debug systemctl start "netctl@$1"
+	cd "$PROFILE_DIR"
+	if [[ ! -r $1 ]]; then
+		exit_error "Profile '$1' does not exist or is not readable"
+	fi
+	# We assume interface names are not quoted
+	# Using read removes leading whitespace
+	read InterfaceLine < \
+		<(grep -om1 "^[[:space:]]*Interface=[[:alnum:]:._-]\+" "$1")
+	if [[ -z $InterfaceLine ]]; then
+		exit_error "Profile '$1' does not specify an interface"
+	fi
+	mapfile -t AllProfiles < <(list_profiles)
+	mapfile -t Profiles < <(grep -Fl "$InterfaceLine" "${AllProfiles[@]}")
+	[[ $Profiles ]] && do_debug systemctl stop "${Profiles[@]/#/netctl@}" 2> \
+		>(grep -Fv "not loaded" >&2)
+	do_debug systemctl start "netctl@$1"
 }
 
 unit_enable() {
-    local unit="/etc/systemd/system/netctl@$1.service"
-    if [[ -e $unit ]]; then
-        report_error "A unit file for profile '$1' already exists"
-        return 1
-    fi
-    load_profile "$1"
-    echo ".include /usr/lib/systemd/system/netctl@.service" > "$unit"
-    echo -e "\n[Unit]" >> "$unit"
-    [[ -n $Description ]] && echo "Description=$Description" >> "$unit"
-    : ${BindsToInterfaces=$Interface}
-    printf 'BindsTo=sys-subsystem-net-devices-%s.device\n' \
-           "${BindsToInterfaces[@]}" >> "$unit"
-    if [[ -n $After ]]; then
-        printf 'After="netctl@%s.service"\n' "${After[@]//\"/\\\"}" >> "$unit"
-    fi
-    systemctl daemon-reload
-    systemctl reenable "netctl@$1.service"
+	local unit="/etc/systemd/system/netctl@$1.service"
+	if [[ -e $unit ]]; then
+		report_error "A unit file for profile '$1' already exists"
+		return 1
+	fi
+	load_profile "$1"
+	echo ".include /usr/lib/systemd/system/netctl@.service" > "$unit"
+	echo -e "\n[Unit]" >> "$unit"
+	[[ -n $Description ]] && echo "Description=$Description" >> "$unit"
+	: ${BindsToInterfaces=$Interface}
+	printf 'BindsTo=sys-subsystem-net-devices-%s.device\n' \
+			"${BindsToInterfaces[@]}" >> "$unit"
+	if [[ -n $After ]]; then
+		printf 'After="netctl@%s.service"\n' "${After[@]//\"/\\\"}" >> "$unit"
+	fi
+	systemctl daemon-reload
+	systemctl reenable "netctl@$1.service"
 }
 
 unit_disable() {
-    local unit="/etc/systemd/system/netctl@$1.service"
-    if systemctl is-enabled --quiet "netctl@$1.service"; then
-        systemctl disable "netctl@$1.service"
-    fi
-    if [[ ! -f $unit ]]; then
-        report_error "No regular unit file found for profile '$1'"
-        return 1
-    fi
-    do_debug rm "$unit"
-    systemctl daemon-reload
+	local unit="/etc/systemd/system/netctl@$1.service"
+	if systemctl is-enabled --quiet "netctl@$1.service"; then
+		systemctl disable "netctl@$1.service"
+	fi
+	if [[ ! -f $unit ]]; then
+		report_error "No regular unit file found for profile '$1'"
+		return 1
+	fi
+	do_debug rm "$unit"
+	systemctl daemon-reload
 }
 
 
 case $# in
-  1)
-    case $1 in
-      --version)
-        report_notice "netctl version $NETCTL_VERSION";;
-      --help)
-        usage;;
-      list)
-        list;;
-      store|restore)
-        ensure_root "$(basename "$0")"
-        "$1";;
-      stop-all)
-        stop_all;;
-      *)
-        exit_error "$(usage)";;
-    esac;;
-  2)
-    case $1 in
-      start|stop|restart|status)
-        systemctl $1 "netctl@$2";;
-      switch-to)
-        ensure_root "$(basename "$0")"
-        switch_to "$2";;
-      enable|disable)
-        ensure_root "$(basename "$0")"
-        "unit_$1" "$2";;
-      reenable)
-        ensure_root "$(basename "$0")"
-        unit_disable "$2"
-        unit_enable "$2";;
-      *)
-        exit_error "$(usage)";;
-    esac;;
-  *)
-    exit_error "$(usage)";;
+	1)
+		case $1 in
+			--version)
+				report_notice "netctl version $NETCTL_VERSION";;
+			--help)
+				usage;;
+			list)
+				list;;
+			store|restore)
+				ensure_root "$(basename "$0")"
+				"$1";;
+			stop-all)
+				stop_all;;
+			*)
+				exit_error "$(usage)";;
+		esac;;
+	2)
+		case $1 in
+			start|stop|restart|status)
+				systemctl $1 "netctl@$2";;
+			switch-to)
+				ensure_root "$(basename "$0")"
+				switch_to "$2";;
+			enable|disable)
+				ensure_root "$(basename "$0")"
+				"unit_$1" "$2";;
+			reenable)
+				ensure_root "$(basename "$0")"
+				unit_disable "$2"
+				unit_enable "$2";;
+			*)
+				exit_error "$(usage)";;
+		esac;;
+	*)
+	exit_error "$(usage)";;
 esac
 
-
-# vim: ft=sh ts=4 et sw=4:
+# vim: ft=sh:

--- a/src/netctl-auto
+++ b/src/netctl-auto
@@ -8,7 +8,7 @@ AUTOWIFI="/usr/sbin/wpa_actiond -p /run/wpa_supplicant"
 ACTION_SCRIPT="$SUBR_DIR/auto.action"
 
 if [[ $# != 2 || $1 != @(start|stop) ]]; then
-    exit_error "Usage: netctl-auto [start|stop] <interface>"
+	exit_error "Usage: netctl-auto [start|stop] <interface>"
 fi
 
 STARTSTOP=$1
@@ -18,61 +18,60 @@ PROFILE_FILE="$STATE_DIR/wpa_actiond_$INTERFACE.profile"
 shift 2
 
 case $STARTSTOP in
-  start)
-    if wpa_is_active "$INTERFACE"; then
-        exit_error "The interface ($INTERFACE) is already in use"
-    fi
-    if [[ -x "$PROFILE_DIR/interfaces/$INTERFACE" ]]; then
-        source "$PROFILE_DIR/interfaces/$INTERFACE"
-    fi
-    if [[ $RFKill ]]; then
-        enable_rf "$INTERFACE" "$RFKill" || exit 1
-    fi
+	start)
+		if wpa_is_active "$INTERFACE"; then
+			exit_error "The interface ($INTERFACE) is already in use"
+		fi
+		if [[ -x "$PROFILE_DIR/interfaces/$INTERFACE" ]]; then
+			source "$PROFILE_DIR/interfaces/$INTERFACE"
+		fi
+		if [[ $RFKill ]]; then
+			enable_rf "$INTERFACE" "$RFKill" || exit 1
+		fi
 
-    if ! WPA_CONF=$(wpa_make_config_file "$INTERFACE"); then
-        exit_error "Could not create the configuration file for interface '$INTERFACE'"
-    fi
-    list_profiles | while read -r profile; do
-        report_debug "Examining profile '$profile'"
-        (
-          source "$PROFILE_DIR/$profile"
-          [[ $Interface == "$INTERFACE" ]] || continue
-          is_yes "${ExcludeAuto:-no}" && exit 1
-          [[ $Connection != "wireless" ]] && exit 1
-          : ${Security:=none}
-          # Exclude wpa-config, the wpa_conf is 'complete' and doesn't fit in this scheme
-          [[ $Security == "wpa-config" ]] && exit 1
+		if ! WPA_CONF=$(wpa_make_config_file "$INTERFACE"); then
+			exit_error "Could not create the configuration file for interface '$INTERFACE'"
+		fi
+		list_profiles | while read -r profile; do
+			report_debug "Examining profile '$profile'"
+			(
+				source "$PROFILE_DIR/$profile"
+				[[ $Interface == "$INTERFACE" ]] || continue
+				is_yes "${ExcludeAuto:-no}" && exit 1
+				[[ $Connection != "wireless" ]] && exit 1
+				: ${Security:=none}
+				# Exclude wpa-config, the wpa_conf is 'complete' and does not fit in this scheme
+				[[ $Security == "wpa-config" ]] && exit 1
 
-          printf "%s\n" "network={" "$(wpa_make_config_block)" "id_str=\"$profile\"" "}" >> "$WPA_CONF"
-          report_notice "Included profile '$profile'"
-        )
-    done
+				printf "%s\n" "network={" "$(wpa_make_config_block)" "id_str=\"$profile\"" "}" >> "$WPA_CONF"
+				report_notice "Included profile '$profile'"
+			)
+		done
 
-    # Start the WPA supplicant
-    : ${WPADriver:=nl80211,wext}
-    WPAOptions+=" -W"
-    if wpa_start "$INTERFACE" "$WPADriver" "$WPA_CONF"; then
-        if $AUTOWIFI -i "$INTERFACE" -P "$PIDFILE" -a "$ACTION_SCRIPT" "$@"; then
-            exit 0
-        fi
-        wpa_stop "$INTERFACE"
-    fi
-    exit 1
-  ;;
-  stop)
-    if [[ -e $PROFILE_FILE ]]; then
-        "$SUBR_DIR/network" stop "$(< "$PROFILE_FILE")" && rm -f "$PROFILE_FILE"
-    else
-        if [[ -x "$PROFILE_DIR/interfaces/$INTERFACE" ]]; then
-            source "$PROFILE_DIR/interfaces/$INTERFACE"
-        fi
-        wpa_stop "$INTERFACE"
-        ip link set dev "$INTERFACE" down
-        [[ $RFKill ]] && disable_rf "$INTERFACE" "$RFKill"
-    fi
-    timeout_wait 1 '[[ ! -f "$PIDFILE" ]]' || kill "$(< "$PIDFILE")"
-  ;;
+		# Start the WPA supplicant
+		: ${WPADriver:=nl80211,wext}
+		WPAOptions+=" -W"
+		if wpa_start "$INTERFACE" "$WPADriver" "$WPA_CONF"; then
+			if $AUTOWIFI -i "$INTERFACE" -P "$PIDFILE" -a "$ACTION_SCRIPT" "$@"; then
+				exit 0
+			fi
+			wpa_stop "$INTERFACE"
+		fi
+		exit 1
+	;;
+	stop)
+		if [[ -e $PROFILE_FILE ]]; then
+			"$SUBR_DIR/network" stop "$(< "$PROFILE_FILE")" && rm -f "$PROFILE_FILE"
+		else
+			if [[ -x "$PROFILE_DIR/interfaces/$INTERFACE" ]]; then
+				source "$PROFILE_DIR/interfaces/$INTERFACE"
+			fi
+			wpa_stop "$INTERFACE"
+			ip link set dev "$INTERFACE" down
+			[[ $RFKill ]] && disable_rf "$INTERFACE" "$RFKill"
+		fi
+		timeout_wait 1 '[[ ! -f "$PIDFILE" ]]' || kill "$(< "$PIDFILE")"
+	;;
 esac
 
-
-# vim: ft=sh ts=4 et sw=4:
+# vim: ft=sh:

--- a/src/wifi-menu
+++ b/src/wifi-menu
@@ -6,7 +6,7 @@
 
 usage()
 {
-    cat << END
+	cat << END
 Usage: wifi-menu [-h | --help] [-o | --obscure] [interface]
 
 Interactively connect to a wireless network.
@@ -23,104 +23,104 @@ END
 # for interface $1.
 init_profiles()
 {
-    local i=0 essid profile
-    while read profile; do
-        essid=$(
-            unset INTERFACE ESSID
-            source "$PROFILE_DIR/$profile" > /dev/null
-            if [[ "$Interface" = "$1" && -n "$ESSID" ]]; then
-                printf "%s" "$ESSID"
-                if [[ "$Description" =~ "Automatically generated" ]]; then
-                    return 2
-                else
-                    return 1
-                fi
-            fi
-            return 0
-        )
-        case $? in
-            2)
-                GENERATED+=("$profile")
-                ;&
-            1)
-                PROFILES[i]=$profile
-                ESSIDS[i]=$essid
-                (( ++i ))
-                ;;
-        esac
-    done < <(list_profiles)
+	local i=0 essid profile
+	while read profile; do
+		essid=$(
+			unset INTERFACE ESSID
+			source "$PROFILE_DIR/$profile" > /dev/null
+			if [[ "$Interface" = "$1" && -n "$ESSID" ]]; then
+				printf "%s" "$ESSID"
+				if [[ "$Description" =~ "Automatically generated" ]]; then
+					return 2
+				else
+					return 1
+				fi
+			fi
+			return 0
+		)
+		case $? in
+			2)
+				GENERATED+=("$profile")
+				;&
+			1)
+				PROFILES[i]=$profile
+				ESSIDS[i]=$essid
+				(( ++i ))
+				;;
+		esac
+	done < <(list_profiles)
 }
 
 # Builds ENTRIES as an argument list for dialog based on scan results in $1.
 init_entries()
 {
-    local i=0 flags signal ssid
-    while IFS=$'\t' read signal flags ssid; do
-        ENTRIES[i++]="--"  # $ssid might look like an option to dialog.
-        ENTRIES[i++]=$ssid
-        if in_array "$ssid" "${ESSIDS[@]}"; then
-            if in_array "$(ssid_to_profile "$ssid")" "${GENERATED[@]}"; then
-                ENTRIES[i]="+"  # Automatically generated
-            else
-                ENTRIES[i]="*"  # Handmade
-            fi
-        else
-            ENTRIES[i]="-"  # Not present
-        fi
-        if [[ "$ssid" = "$CONNECTION" ]]; then
-            ENTRIES[i]="!"  # Currently connected
-        fi
-        if [[ "$flags" =~ WPA2|WPA|WEP ]]; then
-            ENTRIES[i]+=":${BASH_REMATCH[0],,}"
-        else
-            ENTRIES[i]+=":none"
-        fi
-        ENTRIES[i]+="   :$signal"
-        (( ++i ))
-    done < "$1"
+	local i=0 flags signal ssid
+	while IFS=$'\t' read signal flags ssid; do
+		ENTRIES[i++]="--"  # $ssid might look like an option to dialog.
+		ENTRIES[i++]=$ssid
+		if in_array "$ssid" "${ESSIDS[@]}"; then
+			if in_array "$(ssid_to_profile "$ssid")" "${GENERATED[@]}"; then
+				ENTRIES[i]="+"  # Automatically generated
+			else
+				ENTRIES[i]="*"  # Handmade
+			fi
+		else
+			ENTRIES[i]="-"  # Not present
+		fi
+		if [[ "$ssid" = "$CONNECTION" ]]; then
+			ENTRIES[i]="!"  # Currently connected
+		fi
+		if [[ "$flags" =~ WPA2|WPA|WEP ]]; then
+			ENTRIES[i]+=":${BASH_REMATCH[0],,}"
+		else
+			ENTRIES[i]+=":none"
+		fi
+		ENTRIES[i]+="   :$signal"
+		(( ++i ))
+	done < "$1"
 }
 
 # Finds a profile name for ssid $1.
 ssid_to_profile()
 {
-    local i
-    for i in $(seq 0 $((${#ESSIDS[@]}-1))); do
-        if [[ "$1" = "${ESSIDS[i]}" ]]; then
-            printf "%s" "${PROFILES[i]}"
-            return 0
-        fi
-    done
-    return 1
+	local i
+	for i in $(seq 0 $((${#ESSIDS[@]}-1))); do
+		if [[ "$1" = "${ESSIDS[i]}" ]]; then
+			printf "%s" "${PROFILES[i]}"
+			return 0
+		fi
+	done
+	return 1
 }
 
 # Creates a profile for ssid $1.
 create_profile()
 {
-    local box flags key msg security
-    PROFILE="$INTERFACE-${1//\//_}"
-    [[ -e "$PROFILE_DIR/$PROFILE" ]] && PROFILE+=".wifi-menu"
-    flags=$(grep -m 1 $'\t'"$1\$" "$NETWORKS" | cut -f 2)
-    if [[ "$flags" =~ WPA|WEP ]]; then
-        security=${BASH_REMATCH[0],,}
-    else
-        security=none
-    fi
-    if [[ "$flags" =~ PSK|WEP ]]; then
-        [[ "$OBSCURE" ]] && box="--insecure --passwordbox" || box="--inputbox"
-        msg="Enter $security security key for\n'$1'"
-        key=$(dialog $box "$msg" 10 40 --stdout) || return $?
-        if [[ "${#key}" -ge 8 && "${#key}" -le 63 ]]; then
-            if [[ "$OBSCURE" ]]; then
-                key=$(wpa_passphrase "$1" "$key" | grep -m 1 "^[[:space:]]*psk=")
-                key=${key#*psk=}
-            else
-                key=$(printf "%q" "$key")
-            fi
-        elif ! [[ "${#key}" -eq 64 && "$key" = +([[:xdigit:]]) ]]; then
-            return 4
-        fi
-    fi
-    cat << EOF > "$PROFILE_DIR/$PROFILE"
+	local box flags key msg security
+	PROFILE="$INTERFACE-${1//\//_}"
+	[[ -e "$PROFILE_DIR/$PROFILE" ]] && PROFILE+=".wifi-menu"
+	flags=$(grep -m 1 $'\t'"$1\$" "$NETWORKS" | cut -f 2)
+	if [[ "$flags" =~ WPA|WEP ]]; then
+		security=${BASH_REMATCH[0],,}
+	else
+		security=none
+	fi
+	if [[ "$flags" =~ PSK|WEP ]]; then
+		[[ "$OBSCURE" ]] && box="--insecure --passwordbox" || box="--inputbox"
+		msg="Enter $security security key for\n'$1'"
+		key=$(dialog $box "$msg" 10 40 --stdout) || return $?
+		if [[ "${#key}" -ge 8 && "${#key}" -le 63 ]]; then
+			if [[ "$OBSCURE" ]]; then
+				key=$(wpa_passphrase "$1" "$key" | grep -m 1 "^[[:space:]]*psk=")
+				key=${key#*psk=}
+			else
+				key=$(printf "%q" "$key")
+			fi
+		elif ! [[ "${#key}" -eq 64 && "$key" = +([[:xdigit:]]) ]]; then
+			return 4
+		fi
+	fi
+	cat << EOF > "$PROFILE_DIR/$PROFILE"
 Description='Automatically generated profile by wifi-menu'
 Interface=$INTERFACE
 Connection=wireless
@@ -129,74 +129,74 @@ ESSID=$(printf "%q" "$1")
 IP=dhcp
 ${key+Key=$key}
 EOF
-    printf "%s" "$PROFILE"
-    return 0
+	printf "%s" "$PROFILE"
+	return 0
 }
 
 # Connects to ssid $1 using an available profile or an automatically created
 # one if none exists.
 connect_to_ssid()
 {
-    local msg
-    PROFILE=$(ssid_to_profile "$1")
-    if [[ $? -ne 0 ]]; then
-        PROFILE=$(create_profile "$1")
-        RETURN=$?
-        (( RETURN == 0 )) || return $RETURN
-        SPAWNED_PROFILE=1
-    fi
-    clear
-    if ! netctl restart "$PROFILE"; then
-        if (( SPAWNED_PROFILE )); then
-            msg="         CONNECTING FAILED
+	local msg
+	PROFILE=$(ssid_to_profile "$1")
+	if [[ $? -ne 0 ]]; then
+		PROFILE=$(create_profile "$1")
+		RETURN=$?
+		(( RETURN == 0 )) || return $RETURN
+		SPAWNED_PROFILE=1
+	fi
+	clear
+	if ! netctl restart "$PROFILE"; then
+		if (( SPAWNED_PROFILE )); then
+			msg="         CONNECTING FAILED
 
 Do you want to keep the generated profile ('$PROFILE')?"
-            dialog --yesno "$msg" 10 40 --stdout || rm "$PROFILE_DIR/$PROFILE"
-            clear
-        fi
-        return 2
-    fi
-    return 0
+			dialog --yesno "$msg" 10 40 --stdout || rm "$PROFILE_DIR/$PROFILE"
+			clear
+		fi
+		return 2
+	fi
+	return 0
 }
 
 while [[ "$1" = -* ]]; do
-    case "$1" in
-        -h|--help)
-            usage
-            exit
-            ;;
-        -o|--obscure)
-            OBSCURE=1
-            shift
-            ;;
-        -*)
-            report_err "Invalid option: $1"
-            usage
-            exit 255
-            ;;
-    esac
+	case "$1" in
+		-h|--help)
+			usage
+			exit
+			;;
+		-o|--obscure)
+			OBSCURE=1
+			shift
+			;;
+		-*)
+			report_err "Invalid option: $1"
+			usage
+			exit 255
+			;;
+	esac
 done
 if [[ $# -gt 1 ]]; then
-    report_error "Too many arguments"
-    usage
-    exit 255
+	report_error "Too many arguments"
+	usage
+	exit 255
 fi
 
 ensure_root "$(basename "$0")"
 if ! type dialog &> /dev/null; then
-    exit_error "Please install 'dialog' to use wifi-menu"
+	exit_error "Please install 'dialog' to use wifi-menu"
 fi
 
 INTERFACE=${1-wlan0}
 if [[ -z "$INTERFACE" ]]; then
-    report_error "Missing interface specification"
-    usage
-    exit 255
+	report_error "Missing interface specification"
+	usage
+	exit 255
 fi
 
 cd /  # We do not want to spawn anything that can block unmounting
 if [[ ! -d "/sys/class/net/$INTERFACE" ]]; then
-    exit_error "No such interface: $INTERFACE"
+	exit_error "No such interface: $INTERFACE"
 fi
 
 echo -n "Scanning for networks... "
@@ -204,48 +204,48 @@ CONNECTION=$(wpa_call "$INTERFACE" status 2> /dev/null | grep -m 1 "^ssid=")
 CONNECTION=${CONNECTION#ssid=}
 NETWORKS=$(wpa_supplicant_scan "$INTERFACE" 3,4,5)
 if [[ $? -eq 0 ]]; then
-    trap 'rm -f "$NETWORKS"' EXIT
-    echo "done"
-    init_profiles "$INTERFACE"
-    init_entries "$NETWORKS"
-    MSG="Select the network you wish to use
+	trap 'rm -f "$NETWORKS"' EXIT
+	echo "done"
+	init_profiles "$INTERFACE"
+	init_entries "$NETWORKS"
+	MSG="Select the network you wish to use
 Flags description:
  * - handmade profile present
  + - automatically generated profile present
  - - no profile present
  ! - active connection present"
-    CHOICE=$(dialog --column-separator : --menu "$MSG" 24 50 12 \
-                 "${ENTRIES[@]}" --stdout)
-    RETURN=$?
-    if (( RETURN == 0 )); then
-        connect_to_ssid "$CHOICE"
-        RETURN=$?
-    fi
+	CHOICE=$(dialog --column-separator : --menu "$MSG" 24 50 12 \
+				"${ENTRIES[@]}" --stdout)
+	RETURN=$?
+	if (( RETURN == 0 )); then
+		connect_to_ssid "$CHOICE"
+		RETURN=$?
+	fi
 else
-    echo "failed"
-    RETURN=3
+	echo "failed"
+	RETURN=3
 fi
 
 case $RETURN in
-    0|2)  # Connected | Connecting failed
-        ;;
-    1)  # Canceled
-        clear
-        ;;
-    3)  # No networks found
-        report_error "No networks found"
-        ;;
-    4)  # Invalid passphrase length (WEP keys have tighter restrictions)
-        clear
-        report_error "Passphrase must be 8..63 characters"
-        ;;
-    255)  # ESC or error
-        clear
-        report_error "Aborted"
-        ;;
-    *)  # Should not happen
-        report_error "Unexpected return code from dialog: $RETURN"
-        RETURN=7
-        ;;
+	0|2)  # Connected | Connecting failed
+		;;
+	1)  # Canceled
+		clear
+		;;
+	3)  # No networks found
+		report_error "No networks found"
+		;;
+	4)  # Invalid passphrase length (WEP keys have tighter restrictions)
+		clear
+		report_error "Passphrase must be 8..63 characters"
+		;;
+	255)  # ESC or error
+		clear
+		report_error "Aborted"
+		;;
+	*)  # Should not happen
+		report_error "Unexpected return code from dialog: $RETURN"
+		RETURN=7
+		;;
 esac
 exit $RETURN


### PR DESCRIPTION
These settings should be configured by the user in their own ~/.vimrc.
Using tabs instead of spaces supports better compatibility between
various user preferences because the width of tabs/indents is, and
should be, an editor setting.
