### PR TITLE
[wifi-menu] Autodetect network interfaces

### DIFF
--- a/src/wifi-menu
+++ b/src/wifi-menu
@@ -187,11 +187,17 @@ if ! type dialog &> /dev/null; then
     exit_error "Please install 'dialog' to use wifi-menu"
 fi
 
-INTERFACE=${1-wlan0}
+INTERFACE=${1}
 if [[ -z "$INTERFACE" ]]; then
-    report_error "Missing interface specification"
-    usage
-    exit 255
+    w=(/sys/class/net/*/wireless/)
+    if [[ ! -d "${w[0]}" || "${#w[@]}" -gt 1 ]]; then
+        report_error "Invalid interface specification"
+        usage
+        exit 255
+    fi
+    w=("${w[@]%/wireless/}")
+    INTERFACE=("${w[@]##*/}")
+    echo "$INTERFACE"
 fi
 
 cd /  # We do not want to spawn anything that can block unmounting


### PR DESCRIPTION
After the systemd 197 device name changes, wlan0 no longer exists (it
does for people who mask the rule, but new users will have issues with
this). This just searches the /sys/class/net directory for wireless
names and echoes them. If there is more than one, then report an
"Invalid interface specification", not a "Missing" interface (as there
could be multiple).

A quick thanks to Dave Reisner for his help in the channel.

Signed-off-by: William Giokas 1007380@gmail.com
