### PR TITLE
[wifi-menu] Do not fail if already connected

### DIFF
--- a/src/wifi-menu
+++ b/src/wifi-menu
@@ -146,7 +146,7 @@ connect_to_ssid()
         SPAWNED_PROFILE=1
     fi
     clear
-    if ! netctl restart "$PROFILE"; then
+    if ! netctl switch-to "$PROFILE"; then
         if (( SPAWNED_PROFILE )); then
             msg="         CONNECTING FAILED
 


### PR DESCRIPTION
If netctl is already connected to a network and wifi-menu is run, then
it will fail to connect. Having wifi-menu call `netctl switch-to`
instead of `netctl restart` causes wifi-menu to behave like netctl
switch-to: It will connect if not connected, and if already connected on
that interface it will put the connected profile down the put up the
selected profile.

This fixes github issue #6.

Signed-off-by: William Giokas 1007380@gmail.com
