### PR TITLE
[wifi-menu] Add more descriptive interface errors

### DIFF
--- a/src/wifi-menu
+++ b/src/wifi-menu
@@ -190,8 +190,12 @@ fi
 INTERFACE=$1
 if [[ -z "$INTERFACE" ]]; then
     INTERFACE=(/sys/class/net/*/wireless/)
-    if [[ "${#INTERFACE[@]}" -ne 1 || ! -d "$INTERFACE" ]]; then
-        report_error "Invalid interface specification"
+    if [[ "${#INTERFACE[@]}" -gt 1 ]]; then
+        report_error "Multiple interfaces. Use 'ip l' to list interfaces."
+        usage
+        exit 255
+    else if [[ "${#INTERFACE[@]}" -lt 1 || ! -d "$INTERFACE" ]]; then
+        report_error "No network found or specified."
         usage
         exit 255
     fi


### PR DESCRIPTION
Instead of just saying that the interface is invalid, check if there
were multiple interfaces found or if none were found and error
differently.

Signed-off-by: William Giokas 1007380@gmail.com
