### PR TITLE
ExecDownPre is executed BEFORE the con is brought down

### DIFF
--- a/docs/netctl.profile.5.txt
+++ b/docs/netctl.profile.5.txt
@@ -82,7 +82,7 @@ GENERAL OPTIONS
     fail, add ``|| true`' to the end of it.
 
 'ExecDownPre='::
-    A command that is executed after a connection is brought down.
+    A command that is executed before a connection is brought down.
     Similar precautions should be taken as with 'ExecUpPost'.
 
 


### PR DESCRIPTION
ExecDownPre is executed before the connection is brought down, not after, as the man suggests. See netctl/src/lib/network line 75
