### PR TITLE
Expose 'unit' for pppoe connection

### DIFF
--- a/src/lib/connections/pppoe
+++ b/src/lib/connections/pppoe
@@ -52,6 +52,7 @@ pppoe_up() {
     [[ -n ${PPPoEAC} ]] && echo "rp_pppoe_ac $(quote_word "${PPPoEAC}")" >> "${cfg}"
     [[ -n ${PPPoESession} ]] && echo "rp_pppoe_sess $(quote_word "${PPPoESession}")" >> "${cfg}"
     [[ -n ${PPPoEMAC} ]] && echo "pppoe-mac $(quote_word "${PPPoEMAC}")" >> "${cfg}"
+    [[ -n ${PPPoEUnit} ]] && echo "unit ${PPPoEUnit}" >> "${cfg}"
     [[ ${PPPoEIP6} == yes ]] && echo "+ipv6" >> "${cfg}"
 
     if ! $PPPD file "${cfg}"; then


### PR DESCRIPTION
Set PPPoEUnit in 'pppoe' profiles to explicitly specify ppp interface name, so scripts running at Exec\* could take the ppp interface name as parameter correctly when there're more than one pppoe connections.
