### PR TITLE
Use installed DHCP client as default

### DIFF
--- a/src/lib/ip
+++ b/src/lib/ip
@@ -10,6 +10,16 @@ resolvconf_add() {
     printf "%s\n" "$@" | resolvconf -a "$interface"
 }
 
+## Test if executable exists and print its name
+# $1: name of executable
+executable_exists() {
+    command -v "$1" >/dev/null 2>&1 && echo "$1"
+}
+
+## Print the default DHCP client or "false"
+default_dhcp_client() {
+    executable_exists "dhcpcd" || executable_exists "dhclient" || echo "false"
+}
 
 ## Set up an IP configuration
 # $Interface: interface name
@@ -25,7 +35,7 @@ ip_set() {
 
     case $IP in
       dhcp)
-        case ${DHCPClient:-dhcpcd} in
+        case ${DHCPClient:-"$(default_dhcp_client)"} in
           dhcpcd)
             rm -f "/run/dhcpcd-$Interface".{pid,cache}
             # If using own dns, tell dhcpcd to NOT replace resolv.conf
@@ -43,6 +53,10 @@ ip_set() {
                 report_error "DHCP IP lease attempt failed on interface '$Interface'"
                 return 1
             fi
+          ;;
+          false)
+            report_error "No supported DHCP client found - install either dhcpcd or dhclient"
+            return 1
           ;;
           *)
             report_error "Unsupported DHCP client: '$DHCPClient'"


### PR DESCRIPTION
Currently, netctl uses dhclient only if it's explicitly specified in $DHCPClient. Since both supported DHCP clients are listed equally as optional dependencies, I would have expected that dhclient is automatically used if dhcpcd is not installed.

I attached a patch which checks for installed DHCP clients and uses the first one it finds as default.

I'm not an expert bash coder and only had a quick look at the netctl source; I probably didn't grasp all coding conventions and the like. I'll gladly improve my patch according to your suggestions :-)
