### PR TITLE
Added global default DHCP settings and modified documentation to reflect.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ install:
 	# Configuration files
 	install -d $(DESTDIR)/etc/netctl/{examples,hooks,interfaces}
 	install -m644 docs/examples/* $(DESTDIR)/etc/netctl/examples/
+	install -m755 conf/dhcp.conf $(DESTDIR)/etc/netctl/hooks/dhcp.conf
 	# Libs
 	install -d $(DESTDIR)/usr/lib/network/connections
 	install -m644 src/lib/{globals,ip,rfkill,wpa} $(DESTDIR)/usr/lib/network/

--- a/conf/dhcp.conf
+++ b/conf/dhcp.conf
@@ -1,0 +1,19 @@
+# The following DHCP-related options, if specified, will be the global
+# default values for all profiles and all interfaces. Specifying any
+# of these options in a profile or in /etc/netctl/interfaces/<interface>
+# will override the default for that profile or interface, respectively.
+
+# Specify the default DHCP client. Supported options are 'dhcpcd' and 
+# 'dhclient'. Defaults to 'dhcpcd' if not set. Do not use quotes.
+#DHCPClient=dhcpcd
+
+# Specify the default DHCP timeout in seconds. Defaults to '10' if not
+# set. Do not use quotes.
+#TimeoutDHCP=10
+
+# Additional options may be passed to the applicable DHCP client here.
+# Do not use this unless you know what you are doing. Use single 
+# quotes around the desired options.
+#DhcpcdOptions=''
+#DhclientOptions=''
+#DhclientOptions6=''

--- a/contrib/PKGBUILD.in
+++ b/contrib/PKGBUILD.in
@@ -6,6 +6,7 @@ pkgrel=1
 pkgdesc='Profile based systemd network management'
 url='http://projects.archlinux.org/netctl.git/'
 license=('GPL')
+backup=(etc/netctl/hooks/dhcp.conf)
 groups=('base')
 depends=('coreutils' 'iproute2' 'openresolv')
 # The source tarball includes pre-built (using asciidoc) documentation.

--- a/docs/netctl.profile.5.txt
+++ b/docs/netctl.profile.5.txt
@@ -20,11 +20,27 @@ much quoting as possible. For a few WPA-related variables, special
 quoting rules (see below) apply.
 
 The name of the profile is the name of the file. Profile names must not
-contain newlines and should not end in '.service' or '.conf'. Whenever a
-profile is read, all executable scripts in '/etc/netctl/hooks/' and any
-executable script in '/etc/netctl/interfaces/' with the name of the
-interface for the profile are sourced. For each connection type, there
-are example profile files in '/etc/netctl/examples/'.
+contain newlines and should not end in '.service' or '.conf'. 
+
+Whenever a profile is read, all executable scripts in 
+'/etc/netctl/hooks/' and any executable script in 
+'/etc/netctl/interfaces/' with the name of the interface for the profile
+are sourced. In case such scripts define netctl options, any conflicts
+are resolved in the following order of priority:
+
+    '/etc/netctl/interfaces/<interface>' (highest priority)
+    '/etc/netctl/<profile>'
+    '/etc/netctl/hooks/<hook>' (lowest priority)
+    
+Global default values for `DHCPClient' and `TimeoutDHCP', as well as 
+additional options to be passed to the DHCP client, may be specified
+in '/etc/netctl/hooks/dhcp.conf'. Specifying default values obviates
+the need for including such values in each profile. Any value specified
+in a profile will override a conflicting default value specified in
+'/etc/netctl/hooks/dhcp.conf'.
+
+For each connection type, there are example profile files in 
+'/etc/netctl/examples/'.
 
 
 AVAILABLE CONNECTION TYPES


### PR DESCRIPTION
As discussed in Arch bug report 35668 (https://bugs.archlinux.org/task/35668?project=1&cat%5B0%5D=31&string=netctl), I added a DHCP options conf file to /etc/netctl/hooks/dhcp.conf and modified the manpages to reflect these changes. The dhcp.conf file is also documented.

I see no need to symlink the dhcp.conf file to /etc/ or /etc/netctl. The documentation provides  sufficient information regarding what settings can be modified and how.

I don't know how this squares with Arch's preferred location of package .conf files, but I agree with Jouke that doing it this way is the simplest, as it does not require any modifications to the code (unlike my previous approach). 
