### PR TITLE
Adding wpa_actiond handling of hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ install:
 	$(MAKE) -C docs install
 	# Configuration files
 	install -d $(DESTDIR)/etc/netctl/{examples,hooks,interfaces}
+	install -d $(DESTDIR)/etc/netctl/hooks/{connect,disconnect,lost,reestablished,failed}
 	install -m644 docs/examples/* $(DESTDIR)/etc/netctl/examples/
 	# Libs
 	install -d $(DESTDIR)/usr/lib/network/connections

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 # Makefile for netctl documentation
 
-MANPAGES = netctl.1 netctl.profile.5 netctl.special.7
+MANPAGES = netctl.1 netctl.profile.5 netctl.hook.5 netctl.special.7
 
 .PHONY: manpages install $(MANPAGES:=-install) clean
 manpages: $(MANPAGES)

--- a/docs/netctl.hook.5.txt
+++ b/docs/netctl.hook.5.txt
@@ -1,0 +1,58 @@
+NETCTL.HOOK(5)
+=================
+
+NAME
+----
+netctl.hook - Hook options
+
+
+SYNOPSIS
+--------
+netctl.hook
+
+
+DESCRIPTION
+-----------
+Hooks for netctl live under the subdirectories of '/etc/netctl/hooks/'
+and are executable shell scripts. They are sourced in directory order
+upon completion of their respective actions emitted by wpa_actiond.
+
+They are sourced via a bash runtime.
+
+
+AVAILABLE HOOK ACTIONS
+----------------------
++CONNECT+::
+    These scripts are sourced *after* attaining a connection and *after*
+    any 'ExecUpPost=' for the given profile.
++DISCONNECT+::
+    These scripts are sourced *after* any 'ExecDownPre=' and *after*
+    disconnect.
++LOST+::
+    These scripts are sourced when a connection has been deemed lost.
++REESTABLISHED+::
+    These scripts are sourced when a connection has been reestablished.
++FAILED+::
+    These scripts are sourced when an attempt to connect has failed.
+
+
+HOOK PARAMETERS
+---------------
+'$1 -- Interface'::
+    The name of the hardware interface being used. (i.e. wlan0)
+
+'$2 -- SSID'::
+    The Service Set Identifier of the network. (i.e. 2WIRE207)
+
+'$3 -- Profile'::
+    The name of the netctl profile currently in use.
+    (i.e. wlan0-2WIRE207)
+
+'$4 -- Action'::
+    The all-uppercase wpa_actiond action being hooked to.
+    (i.e. CONNECT)
+
+
+SEE ALSO
+--------
+*netctl*(1)

--- a/docs/netctl.profile.5.txt
+++ b/docs/netctl.profile.5.txt
@@ -21,11 +21,10 @@ quoting rules (see below) apply.
 
 The name of the profile is the name of the file. Profile names must not
 contain newlines and should not end in '.service' or '.conf'. Whenever a
-profile is read, all executable scripts in '/etc/netctl/hooks/' and any
-executable script in '/etc/netctl/interfaces/' with the name of the
-interface for the profile are sourced. Declarations in an interface
-script override declarations in a profile, which override declarations
-in hooks. For each connection type, there are example profile files in
+profile is read, any executable script in '/etc/netctl/interfaces/' with
+the name of the interface for the profile is sourced. Declarations in
+an interface script override declarations in a profile. For each
+connection type, there are example profile files in
 '/etc/netctl/examples/'.
 
 

--- a/src/lib/auto.action
+++ b/src/lib/auto.action
@@ -28,6 +28,7 @@ case $action in
         netctl-auto stop "$interface"
         exit 1
     fi
+    load_hooks "$@"
   ;;
   DISCONNECT)
     if [[ -z $profile ]]; then
@@ -38,14 +39,15 @@ case $action in
     if ! ( eval $ExecDownPre ); then
         exit 1
     fi
+    load_hooks "$@"
     ip_unset
   ;;
   LOST|REESTABLISHED)
-    # Not handled.
+    load_hooks "$@"
     exit 0
   ;;
-  *)
-    # ???
+  FAILED|*)
+    load_hooks "$@"
     exit 1
   ;;
 esac

--- a/src/lib/globals
+++ b/src/lib/globals
@@ -96,16 +96,25 @@ list_profiles() {
     find -L "$PROFILE_DIR/" -maxdepth 1 -type f -not -name '.*' -not -name '*~' -not -name '*.conf' -not -name '*.service' -printf "%f\n"
 }
 
+## Sources all hooks for particular event
+# $1: interface
+# $2: ssid
+# $3: profile
+# $4: action
+load_hooks() {
+    local action=${4,,}
+    [ ! -d "$PROFILE_DIR/hooks/$action" ] && return 0
+    while read -r hook; do
+        source "$hook" "$@"
+    done < <(find -L "$PROFILE_DIR/hooks/$action" -maxdepth 1 -type f -executable -not -name '.*' -not -name '*~' | sort -u)
+}
+
 ## Sources all hooks, a profile and any interface hook
 # $1: profile name
 load_profile() {
-    local hook
     if [[ ! -r "$PROFILE_DIR/$1" ]]; then
         exit_error "Profile '$1' does not exist or is not readable"
     fi
-    while read -r hook; do
-        source "$hook"
-    done < <(find -L "$PROFILE_DIR/hooks" -maxdepth 1 -type f -executable -not -name '.*' -not -name '*~' | sort -u)
     source "$PROFILE_DIR/$1"
     if [[ -z $Interface ]]; then
         exit_error "Profile '$1' does not specify an interface"


### PR DESCRIPTION
This is a departure from the original handling of hooks. I wanted some more flexibility of when hooks were sourced and some more clarification of when those hooks were actually sourced.

I have added a new manpage (section 5) for netctl.hook
I have modified the language referring to hooks in netctl.profile(5)

I have moved the sourcing of the hooks directory to the auto.action cases.

I tried to find instances when hooks were called for ifplugd/wired interfaces, but came back empty-handed. 
