### PR TITLE
wifi-menu: fix a typo

### DIFF
--- a/src/wifi-menu
+++ b/src/wifi-menu
@@ -41,7 +41,7 @@ init_profiles()
         case $? in
             2)
                 GENERATED+=("$profile")
-                ;&
+                ;;
             1)
                 PROFILES[i]=$profile
                 ESSIDS[i]=$essid


### PR DESCRIPTION
I don't know what does that fix, but it seems like a typo.
