### PR TITLE
wifi-menu: Allow to enter a custom profile name using the -n switch

### DIFF
--- a/src/wifi-menu
+++ b/src/wifi-menu
@@ -93,28 +93,18 @@ ssid_to_profile()
     return 1
 }
 
-# Asks the user for a profile name, defaulting to $1, and printing the name to
-# stdout -- returning 1 if canceled
-ask_profile_name()
+# Ask the user for the name of the new profile
+confirm_profile()
 {
-    PROFILE="$1"
-    msg="Enter profile name"
-    PROFILE=$(dialog --inputbox "$msg" 8 60 "$PROFILE" --stdout) || return $?
-    if [[ -e "$PROFILE_DIR/$PROFILE" ]]; then
-        # Profile with this name already exists, confirm overwrite
-        if dialog --yesno "The profile '$PROFILE' already exists. Overwrite?" 8 60 --stdout; then
-            # Overwrite, return the profile name
-            echo $PROFILE
-            return 0
-        else
-            # Don't overwrite, ask for a different name
-            ask_profile_name $PROFILE
-            return $?
-        fi
-    else
-        echo $PROFILE
-        return 0
-    fi
+    local msg="Enter a name for the new profile\n"
+    PROFILE=$(dialog --inputbox "$msg" 10 50 "$PROFILE" --stdout) || return $?
+    if [[ $PROFILE = */* ]]; then
+        PROFILE=${PROFILE//\//_}
+        confirm_profile
+    elif [[ -e "$PROFILE_DIR/$PROFILE" ]]; then
+        msg="A profile by the name '$PROFILE' already exists.
+Do you want to overwrite it?"
+        dialog --yesno "$msg" 10 50 --stdout || confirm_profile
 }
 
 # Creates a profile for ssid $1.
@@ -123,7 +113,7 @@ create_profile()
     local box flags key msg security
     PROFILE="$INTERFACE-${1//\//_}"
     [[ -e "$PROFILE_DIR/$PROFILE" ]] && PROFILE+=".wifi-menu"
-    PROFILE=$(ask_profile_name "$PROFILE") || return 1
+    confirm_profile || return $?
     flags=$(grep -m 1 $'\t'"$1\$" "$NETWORKS" | cut -f 2)
     if [[ "$flags" =~ WPA|WEP ]]; then
         security=${BASH_REMATCH[0],,}


### PR DESCRIPTION
Me and a few other users I talked to prefer to enter their own name for the profiles generated by wifi-menu, instead of the default `<interface>-<essid>` pattern. I implemented this using an additional switch `-n|--ask-name`, asking for the new profile name before the security key. If this switch is not supplied, wifi-menu behaves as normal.
