### PR TITLE
wifi-menu: Use proper quoting syntax for hexadecimal keys

### DIFF
--- a/src/wifi-menu
+++ b/src/wifi-menu
@@ -128,6 +128,8 @@ create_profile()
         if [[ "${#key}" -ge 8 && "${#key}" -le 63 ]]; then
             if [[ "$OBSCURE" ]]; then
                 key='\"'$(wpa_passphrase "$1" "$key" | sed -n "s/^[[:space:]]*psk=//p")
+            elif [[ "$flags" =~ WEP && "$key" = +([[:xdigit:]]) ]] && ((${#key} % 2 == 0)); then
+                key='\"'$key
             else
                 key=$(printf "%q" "$key")
             fi


### PR DESCRIPTION
I noticed that profiles generated by `wifi-menu -o` don't use the "Special quoting rules" for hexadecimal keys given at the end of [netctl.profile(5)](https://github.com/joukewitteveen/netctl/blob/master/docs/netctl.profile.5.txt#L446).  This prefixes both auto-generated and manually-entered hexadecimal keys with `\"`.

This looks like the same wifi-menu issue mentioned in #67.
