### PR TITLE
Added support for 'macvlan' link type to vlan connection profile

### DIFF
--- a/docs/examples/vlan-dhcp
+++ b/docs/examples/vlan-dhcp
@@ -1,7 +1,13 @@
 Description='Virtual LAN 55 on interface eth0 using DHCP'
 Interface=eth0.55
 Connection=vlan
+Type="vlan"
 # The variable name is plural, but needs precisely one interface
 BindsToInterfaces=eth0
+# Optional static MAC address for macvlan type links, random if blank
+MACAddress=""
+# Mode for macvlan type links
+Mode="bridge"
+# ID for vlan type links
 VLANID=55
 IP=dhcp

--- a/docs/examples/vlan-static
+++ b/docs/examples/vlan-static
@@ -1,8 +1,14 @@
 Description='Virtual LAN 11 on interface eth0'
 Interface=eth0.11
 Connection=vlan
+Type="vlan"
 # The variable name is plural, but needs precisely one interface
 BindsToInterfaces=eth0
+# Optional static MAC address for macvlan type links, random if blank
+MACAddress=""
+# Mode for macvlan type links
+Mode="bridge"
+# ID for vlan type links
 VLANID=11
 IP=static
 Address="192.168.0.100/24"

--- a/docs/netctl.profile.5.txt
+++ b/docs/netctl.profile.5.txt
@@ -53,7 +53,7 @@ AVAILABLE CONNECTION TYPES
 +tuntap+::
     For TUN/TAP interfaces.
 +vlan+::
-    For VLANs on ethernet-like connections.
+    For VLANs and MAC VLANs on ethernet-like connections.
 
 
 GENERAL OPTIONS
@@ -439,8 +439,21 @@ Hence, for vlan profiles, 'BindsToInterfaces' contains the name of a
 single network interface.
 
 All options for connections of the `ethernet' type are understood for
-connections of the `vlan' type. Additionally, connections of the `vlan'
-type can set a vlan identifier using 'VLANID='. See *ip*(8) for details.
+connections of the `vlan' type. Next to the `ethernet' type options,
+the following are understood for connections of the `vlan' type:
+
+'Type='::
+    Either `vlan', or `macvlan'. See *ip*(8) for details.
+
+'MACAddress='::
+    Optional static MAC address for `macvlan' type links.
+
+'Mode='::
+    Mode setting for `macvlan' type links. Either `bridge', `vepa',
+    `private', or `passthru'.
+
+'VLANID='::
+    VLAN ID of for `vlan' type links. See *ip*(8) for details.
 
 
 SPECIAL QUOTING RULES

--- a/src/lib/connections/vlan
+++ b/src/lib/connections/vlan
@@ -2,6 +2,10 @@
 
 . "$CONN_DIR/ethernet"
 
+macvlan_valid_mode() {
+    [[ "$1" =~ (bridge)|(passthru)|(private)|(vepa) ]] 
+}
+
 vlan_up() {
     if [[ ${#BindsToInterfaces[@]} -ne 1 ]]; then
         report_error "No unique physical device for VLAN interface '$Interface' specified"
@@ -12,7 +16,31 @@ vlan_up() {
         return 1
     else
         bring_interface_up "$BindsToInterfaces"
-        ip link add link "$BindsToInterfaces" name "$Interface" type vlan id "$VLANID"
+        case "$Type" in
+            macvlan)
+                if [ -z "$Mode" ]; then
+                    report_error "Mode not set for MAC VLAN interface $Interface"
+                    return 1
+                else
+                    if macvlan_valid_mode "$Mode"; then
+                        if [ -z "$MACAddress" ]; then
+                            ip link add link "$BindsToInterface" name "$Interface" type macvlan mode "$Mode"
+                        else
+                            ip link add link "$BindsToInterdace" name "$Interface" address "$MACAddress" type macvlan mode "$Mode"
+                        fi
+                    else
+                        report_error "Invalid mode '$Mode' for MAC VLAN interface $Interface"
+                        return 1
+                    fi
+                fi
+            ;;
+            vlan)
+                ip link add link "$BindsToInterfaces" name "$Interface" type vlan id "$VLANID"
+            ;;
+            *)
+                ip link add link "$BindsToInterfaces" name "$Interface" type vlan id "$VLANID"
+            ;;
+        esac
     fi
 
     ethernet_up


### PR DESCRIPTION
I recently ran into a situation where I wanted to create 'macvlan' type links with netctl and saw that the 'vlan' connection profile only supported the 'vlan' link type. I added code to choose and create either a 'vlan' or 'macvlan', similar to the 'tuntap' profile, to easily create these devices without using the 'custom' profile. Also a minor doc edit to the 'vlan' description where it seemed like the VLANID variable was optional but is not. 
