### PR TITLE
Adding full support for IPIP Tunnel

### DIFF
--- a/docs/netctl.profile.5.txt
+++ b/docs/netctl.profile.5.txt
@@ -413,6 +413,9 @@ the *ip options*, the following are understood for connections of the
 
 'Remote='::
     The address of the remote end of the tunnel.
+    
+'PoinToPoint='::
+    The address of the Peer-to-Peer end of the tunnel.
 
 
 OPTIONS FOR `tuntap' CONNECTIONS

--- a/docs/netctl.profile.5.txt
+++ b/docs/netctl.profile.5.txt
@@ -103,7 +103,7 @@ network. In particular, these connection types are +ethernet+,
 +wireless+, +bond+, +bridge+, +tunnel+, +tuntap+, and +vlan+.
 
 'IP=' [mandatory for IPv4]::
-    One of `static', `dhcp', or `no', depending on the desired way of
+    One of `static', `staticp2p', `dhcp', or `no', depending on the desired way of
     obtaining an address.
 
 'IP6=' [mandatory for IPv6]::
@@ -415,7 +415,7 @@ the *ip options*, the following are understood for connections of the
     The address of the remote end of the tunnel.
     
 'PoinToPoint='::
-    The address of the Peer-to-Peer end of the tunnel.
+    The address of the Peer-to-Peer end of the tunnel. Available only in IP=staticp2p
 
 
 OPTIONS FOR `tuntap' CONNECTIONS

--- a/src/lib/ip
+++ b/src/lib/ip
@@ -76,6 +76,15 @@ ip_set() {
             fi
         done
       ;;
+      staticp2p)
+        for addr in "${Address[@]}"; do
+            #if ! do_debug ip addr add "$addr" brd + dev "$Interface"; then
+            if ! do_debug ifconfig "$Interface" "$addr"  pointopoint $PoinToPoint; then
+                report_error "Could not add address '$addr' to interface '$Interface'"
+                return 1
+            fi
+        done
+      ;;
       ""|no)
       ;;
       *)


### PR DESCRIPTION
To create ipip tunnel with netctl you need to provide pointopoint parameter for this command:
ifconfig tun0 10.0.0.1 netmask 255.255.255.252 __pointopoint__ _10.0.0.2_

This pull request provide this by adding `IP=staticp2p`
and aditional variable `PoinToPoint='10.0.0.2'`