### PR TITLE
Change how netctl-auto looks for active interfaces

### DIFF
--- a/src/netctl-auto
+++ b/src/netctl-auto
@@ -253,6 +253,9 @@ case $# in
       switch-to)
         switch_to "$2";;
       start|stop)
+        if tty -s; then
+            exit_error "Use 'systemctl $1 netctl-auto@$2' to $1 the netctl-auto service."
+        fi
         ensure_root "$(basename "$0")"
         "$1" "$2";;
       *)


### PR DESCRIPTION
This fixes a bug where non-root users could not use netctl-auto to enable or disable individual profiles any more.

In order to get a list of interfaces for which the netctl-auto service is active, the netctl-auto utility currently looks for wpa_actiond pid files in `/run/network`.
However, since 8a41497 this will fail when executed by a non-root user, even though the user is in the `wheel` group and is actually allowed to control `wpa_supplicant` (and therefore also has permission to use netctl-auto).

This patch searches for running netctl-auto services in systemd in order to get a list of active interfaces.
