### PR TITLE
port bonding from ifenslave to iproute2

### DIFF
--- a/README
+++ b/README
@@ -11,7 +11,6 @@ Optional:
 - dialog: for the interactive assistant
 - ifplugd: for automatic connection
 - wpa_actiond: for automatic connection
-- ifenslave: for bonding support
 - bridge-utils: for bridge support
 
 For documentation generation:

--- a/contrib/PKGBUILD.in
+++ b/contrib/PKGBUILD.in
@@ -16,7 +16,6 @@ optdepends=('dialog: for the menu based wifi assistant'
             'wpa_supplicant: for wireless networking support'
             'ifplugd: for automatic wired connections through netctl-ifplugd'
             'wpa_actiond: for automatic wireless connections through netctl-auto'
-            'ifenslave: for bond connections'
             'ppp: for pppoe connections'
            )
 source=(ftp://ftp.archlinux.org/other/packages/netctl/netctl-${pkgver}.tar.xz{,.sig})

--- a/docs/netctl.profile.5.txt
+++ b/docs/netctl.profile.5.txt
@@ -37,8 +37,7 @@ AVAILABLE CONNECTION TYPES
     For wireless connections. This connection type requires
     *wpa_supplicant* to be available.
 +bond+::
-    Network bonding. This connection type requires *ifenslave* to be
-    available.
+    Network bonding.
 +bridge+::
     Network bridging. This connection type requires *brctl* to be
     available.

--- a/src/lib/connections/bond
+++ b/src/lib/connections/bond
@@ -2,7 +2,6 @@
 
 . "$SUBR_DIR/ip"
 
-: ${IFENSLAVE:=ifenslave}
 declare -ag BindsToInterfaces
 
 bond_up() {
@@ -15,8 +14,8 @@ bond_up() {
     bring_interface_up "$Interface"
 
     for slave in "${BindsToInterfaces[@]}"; do
-        bring_interface_up "$slave"
-        $IFENSLAVE "$Interface" "$slave"
+        bring_interface_down "$slave"
+        ip link set "$slave" master "$Interface"
     done
 
     ip_set
@@ -24,7 +23,7 @@ bond_up() {
 
 bond_down() {
     for slave in "${BindsToInterfaces[@]}"; do
-        $IFENSLAVE "$Interface" -d "$slave"
+        ip link set "$slave" nomaster
     done
 
     ip_unset


### PR DESCRIPTION
Ifenslave is deprecated according to [the kernel documentation](https://www.kernel.org/doc/Documentation/networking/bonding.txt).
It also added an additional, unnecessary dependency. I tried to update the documentation to reflect this change.
