### PR TITLE
mobile_ppp: Don't pass invalid arguments to kill command

### DIFF
--- a/src/lib/connections/mobile_ppp
+++ b/src/lib/connections/mobile_ppp
@@ -84,7 +84,7 @@ mobile_ppp_down() {
     chat="$STATE_DIR/mobile_ppp.$Interface.$Profile/modem.chat"
     pidfile="/var/run/ppp-$Profile.pid"
 
-    [[ -r $pidfile ]] && kill "$(< "$pidfile")"
+    [[ -r $pidfile ]] && kill "$(head -1 $pidfile)"
 
     rm "$options" "$chat"
     rmdir "$(dirname "$options")"


### PR DESCRIPTION
#### Description

Stopping mobile PPP connections does not work right now because invalid arguments are passed to the `kill` command.

In the file [src/lib/connections/mobile_ppp](https://github.com/joukewitteveen/netctl/blob/master/src/lib/connections/mobile_ppp) the function `mobile_ppp_down()` is called to kill the PPP connection.

The following command is used to kill pppd (line 87 in current master):

``` bash
[[ -r $pidfile ]] && kill "$(< "$pidfile")"
```

The pid file looks like this:

``` bash
cat /var/run/ppp-mobile.pid
6104
ppp0
```

The log tells me:

``` bash
journalctl -xn
Mar 12 17:36:57 host network[3141]: /usr/lib/network/connections/mobile_ppp: line 87: kill: 2879
Mar 12 17:36:57 host network[3141]: ppp0: arguments must be process or job IDs
```

The kill command does not work becuase it contains more than just the PID. Currently the complete file is passed.
#### Fix

This pull request fixes this issue, it only passes the first line of the PID file to the kill command.
#### Version info

``` bash
pppd --version
pppd version 2.4.6
```
