### PR TITLE
add is-enabled subcommand

### DIFF
--- a/src/netctl.in
+++ b/src/netctl.in
@@ -21,6 +21,7 @@ Commands:
   enable [PROFILE]     Enable the systemd unit for a profile
   disable [PROFILE]    Disable the systemd unit for a profile
   reenable [PROFILE]   Reenable the systemd unit for a profile
+  is-enabled [PROFILE] Check whether the profile is currently enabled
 END
 }
 
@@ -101,6 +102,11 @@ switch_to() {
     do_debug sd_call start "$1"
 }
 
+unit_is_enabled() {
+    local unit="@systemdsystemconfdir@/netctl@$(sd_escape "$1").service"
+    [[ -e $unit ]]
+}
+
 unit_enable() {
     local unit="@systemdsystemconfdir@/netctl@$(sd_escape "$1").service"
     if [[ -e $unit ]]; then
@@ -162,6 +168,8 @@ case $# in
     case $1 in
       start|stop|restart|status)
         sd_call "$1" "$2";;
+      is-enabled)
+        unit_is_enabled "$2";;
       switch-to)
         ensure_root "$(basename "$0")"
         switch_to "$2";;


### PR DESCRIPTION
Provides a simple programmatic interface to determine whether a netctl interface is presently enabled; mirrors the systemctl is-enabled subcommand.
