### PR TITLE
replace [[ -v ]] by testing result of "declare -p"

### DIFF
--- a/src/netctl.in
+++ b/src/netctl.in
@@ -111,7 +111,10 @@ unit_enable() {
     echo ".include @systemdsystemunitdir@/netctl@.service" > "$unit"
     echo -e "\n[Unit]" >> "$unit"
     [[ -n $Description ]] && echo "Description=$Description" >> "$unit"
-    [[ -v BindsToInterfaces ]] || BindsToInterfaces=$Interface
+    # in Bash, it's a bit awkward to check if a potentially empty
+    # array is (not) declared:
+    declare -p BindsToInterfaces >/dev/null 2>&1 || \
+        BindsToInterfaces=$Interface
     if (( ${#BindsToInterfaces[@]} )); then
         : ${InterfaceRoot=sys/subsystem/net/devices/}
         printf "BindsTo=$(sd_escape "$InterfaceRoot")%s.device\n" \


### PR DESCRIPTION
For empty arrays, Bash's [[ -v ... ]] will return false. This is
not what we want here, so we test for an existing variable definition
using "declare -p".

Potential fix for issue #87.
