### PR TITLE
Automatic profile selection based on host availability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install:
 	install -m644 docs/examples/* $(DESTDIR)/etc/netctl/examples/
 	# Libs
 	install -d $(DESTDIR)/usr/lib/network/{connections,dhcp}
-	install -m644 src/lib/{globals,ip,rfkill,wpa} $(DESTDIR)/usr/lib/network/
+	install -m644 src/lib/{globals,ip,rfkill,wpa,test} $(DESTDIR)/usr/lib/network/
 	install -m644 src/lib/connections/* $(DESTDIR)/usr/lib/network/connections/
 	install -m644 src/lib/dhcp/* $(DESTDIR)/usr/lib/network/dhcp/
 	install -m755 src/lib/{auto.action,network} $(DESTDIR)/usr/lib/network/

--- a/README
+++ b/README
@@ -11,6 +11,7 @@ Optional:
 - dialog: for the interactive assistant
 - ifplugd: for automatic connection
 - wpa_actiond: for automatic connection
+- arptest: for automatic connection testing
 
 For documentation generation:
 - asciidoc

--- a/docs/examples/ethernet-auto-test
+++ b/docs/examples/ethernet-auto-test
@@ -1,0 +1,11 @@
+Description='A basic static ethernet connection with tests'
+Interface=eth0
+Connection=ethernet
+IP=static
+Address=('192.168.1.23/24' '192.168.1.87/24')
+#Routes=('192.168.0.0/24 via 192.168.1.2')
+Gateway='192.168.1.1'
+DNS=('192.168.1.1')
+
+# Gateway has MAC address 00:00:5E:00:53:AB, test for it
+Tests=('192.168.1.1|00:00:5E:00:53:AB')

--- a/docs/netctl.profile.5.txt
+++ b/docs/netctl.profile.5.txt
@@ -194,6 +194,24 @@ network. In particular, these connection types are +ethernet+,
     Whether or not to bypass Duplicate Address Detection altogether.
     Defaults to `++no++'.
 
+'Tests=()'::
+    An array of IP addresses (and optionally, MAC addresses) to test
+    the existence of for automatic profile selection.
+    Format is `192.0.2.1' to test for any MAC address, or
+    `192.0.2.2|00:00:5E:00:53:12' to test for a particular MAC address.
+    Any successful tests mark the profile as successful, as does having
+    no tests defined at all.
+    Currently only supports IPv4!
+
+'ExcludeAuto='::
+    Whether or not to exclude this profile from automatic profile
+    selection. Defaults to `++no++'.
+
+'Priority='::
+    Priority group for the network. In case of automatic profile
+    selection, the matched network with the highest priority will be
+    selected. Defaults to `++0++'.
+
 
 OPTIONS FOR `ethernet' CONNECTIONS
 ----------------------------------
@@ -259,11 +277,6 @@ of the `wireless' type:
     A frequency in MHz to use in ad-hoc mode when a new IBSS is created
     (i.e. the network is not already present).
 
-'Priority='::
-    Priority group for the network. In case of automatic profile
-    selection, the matched network with the highest priority will be
-    selected. Defaults to `++0++'.
-
 'WPAConfigSection=()' [mandatory for 'Security=wpa-configsection']::
     Array of lines that form a network block for *wpa_supplicant*. All
     of the above options will be ignored.
@@ -294,10 +307,6 @@ of the `wireless' type:
     in '/sys/class/rfkill/rfkillX/name'. It is also possible to set this
     variable to `++auto++'. In that case an *rfkill* device that is
     associated with the network interface is used.
-
-'ExcludeAuto='::
-    Whether or not to exclude this profile from automatic profile
-    selection. Defaults to `++no++'.
 
 
 OPTIONS FOR `bond' CONNECTIONS

--- a/src/ifplugd.action
+++ b/src/ifplugd.action
@@ -3,51 +3,49 @@
 # ifplugd.action script for netctl
 
 . /usr/lib/network/globals
+. "$SUBR_DIR/test"
 
 PROFILE_FILE="$STATE_DIR/ifplugd_$1.profile"
 
 case "$2" in
   up)
-    # Look for a dhcp based profile to try first
-    # dhcp can actually outright fail, whereas
-    # it's difficult to tell if static succeeded
-    # Also check profile is same iface and is right connection
     echo "up"
-    declare -a preferred_profiles
-    declare -a dhcp_profiles
-    declare -a static_profiles
+    priority=0
     while read -r profile; do
-        (
-          echo "Reading profile '$profile'"
+        echo "Reading profile '$profile'"
+        new_priority=$(
           source "$PROFILE_DIR/$profile"
-          [[ "$Interface" == "$1" && "$Connection" == "ethernet" ]] || continue
-          is_yes "${AutoWired:-no}" && exit 1 # user preferred AUTO profile
-          [[ "$IP" == "dhcp" ]] && exit 2 # dhcp profile
-          exit 3 # static profile
+          [[ "$Interface" == "$1" && "$Connection" == "ethernet" ]] || exit 1
+          is_yes "${ExcludeAuto:-no}" && exit 1
+          : ${Priority:=0}
+
+          if test_profile; then
+              echo "$Priority"
+              exit 0
+          fi
+          exit 1
         )
-        case $? in
-          1) preferred_profiles+=("$profile");;
-          2) dhcp_profiles+=("$profile");;
-          3) static_profiles+=("$profile");;
-        esac
+        if (( $? == 0 )); then
+            if [[ -z $selected ]] || (( new_priority >= priority )); then
+                selected=$profile
+                priority=$new_priority
+            fi
+        fi
     done < <(list_profiles)
-    if [[ ${#preferred_profiles[@]} > 1 ]]; then
-        echo "AutoWired flag for '$1' set in more than one profile (${preferred_profiles[*]})"
-    fi
-    for profile in "${preferred_profiles[@]}" "${dhcp_profiles[@]}" "${static_profiles[@]}"; do
-        if ForceConnect=yes "$SUBR_DIR/network" start "$profile"; then
+    if [[ $selected ]]; then
+        if ForceConnect=yes "$SUBR_DIR/network" start "$selected"; then
             mkdir -p "$(dirname "$PROFILE_FILE")"
-            printf "%s" "$profile" > "$PROFILE_FILE"
+            printf "%s" "$selected" > "$PROFILE_FILE"
             exit 0
         fi
-    done
+    fi
   ;;
   down)
     if [[ -e "$PROFILE_FILE" ]]; then
-        if ForceConnect=yes "$SUBR_DIR/network" stop "$(< "$PROFILE_FILE")"; then
-            rm -f "$PROFILE_FILE"
-            exit 0
-        fi
+        profile=$(< "$PROFILE_FILE")
+        "$SUBR_DIR/network" stop "$profile"
+        rm -f "$PROFILE_FILE"
+        exit 0
     fi
   ;;
   *)

--- a/src/lib/test
+++ b/src/lib/test
@@ -1,0 +1,50 @@
+## /usr/lib/network/globals needs to be sourced before this file
+
+
+## Run profile tests, success if any succeed
+# $Interface: interface name
+# $IP: set if IPv4 used
+# $IP6: set if IPv6 used
+# $Tests: array of addresses to test
+test_profile() {
+    local macaddr ipaddr test testcmd cmdargs
+
+    # No tests is automatic success
+    if [[ -z $Tests ]]; then
+        return 0
+    fi
+
+    if [[ $IP ]]; then
+        testcmd=arptest
+    elif [[ $IP6 ]]; then
+        #testcmd=ndptest
+        report_error "Testing on IPv6 not supported"
+        return 1
+    else
+        report_error "No IP type defined for testing"
+        return 1
+    fi
+
+    for test in "${Tests[@]}"; do
+        IFS="|" read -r ipaddr macaddr <<< "$test"
+        if [[ -z $ipaddr ]]; then
+            report_error "Unable to parse test '$test'"
+            return 1
+        fi
+
+        # 0.1 second timeout
+        cmdargs=( -w 0.1 )
+        if [[ $macaddr ]]; then
+            cmdargs+=( -m "$macaddr" )
+        fi
+        cmdargs+=( "$Interface" "$ipaddr" )
+
+        # Run test, exit if successful
+        if $testcmd "${cmdargs[@]}" >/dev/null; then
+            return 0
+        fi
+    done
+
+    # No test succeeded
+    return 1
+}


### PR DESCRIPTION
This introduces support for host availability testing via [arptest](https://github.com/Xenopathic/arptest). The syntax is simple; the following will test for either a host at 192.168.2.1 or a host with MAC address aa:bb:cc:dd:ee:ff at 192.168.2.2:

    Tests=('192.168.2.1' '192.168.2.2|aa:bb:cc:dd:ee:ff')

This is implemented as part of the ifplugd action.

Why is this so cool? I can now take my laptop, plug it into my home network and get my custom static profile. Or when I'm somewhere else, the DHCP profile will come into effect. No starting profiles manually anymore!

Only issue with integrating this into Arch is packaging - I have packaged arptest into the AUR at https://aur.archlinux.org/packages/arptest-git/, however netctl is in core, so it would likewise need to be packaged there or in one of the other official repos.

No IPv6 support yet, although it is just a matter of porting arptest to the IPv6 protocols (Neighbor Discovery Protocol).