### PR TITLE
Unify wireless auto settings and wired auto settings

### DIFF
--- a/docs/netctl.profile.5.txt
+++ b/docs/netctl.profile.5.txt
@@ -194,6 +194,15 @@ network. In particular, these connection types are +ethernet+,
     Whether or not to bypass Duplicate Address Detection altogether.
     Defaults to `++no++'.
 
+'ExcludeAuto='::
+    Whether or not to exclude this profile from automatic profile
+    selection. Defaults to `++no++'.
+
+'Priority='::
+    Priority group for the network. In case of automatic profile
+    selection, the matched network with the highest priority will be
+    selected. Defaults to `++0++'.
+
 
 OPTIONS FOR `ethernet' CONNECTIONS
 ----------------------------------
@@ -259,11 +268,6 @@ of the `wireless' type:
     A frequency in MHz to use in ad-hoc mode when a new IBSS is created
     (i.e. the network is not already present).
 
-'Priority='::
-    Priority group for the network. In case of automatic profile
-    selection, the matched network with the highest priority will be
-    selected. Defaults to `++0++'.
-
 'WPAConfigSection=()' [mandatory for 'Security=wpa-configsection']::
     Array of lines that form a network block for *wpa_supplicant*. All
     of the above options will be ignored.
@@ -294,10 +298,6 @@ of the `wireless' type:
     in '/sys/class/rfkill/rfkillX/name'. It is also possible to set this
     variable to `++auto++'. In that case an *rfkill* device that is
     associated with the network interface is used.
-
-'ExcludeAuto='::
-    Whether or not to exclude this profile from automatic profile
-    selection. Defaults to `++no++'.
 
 
 OPTIONS FOR `bond' CONNECTIONS

--- a/src/ifplugd.action
+++ b/src/ifplugd.action
@@ -8,46 +8,40 @@ PROFILE_FILE="$STATE_DIR/ifplugd_$1.profile"
 
 case "$2" in
   up)
-    # Look for a dhcp based profile to try first
-    # dhcp can actually outright fail, whereas
-    # it's difficult to tell if static succeeded
-    # Also check profile is same iface and is right connection
     echo "up"
-    declare -a preferred_profiles
-    declare -a dhcp_profiles
-    declare -a static_profiles
+    priority=0
     while read -r profile; do
-        (
-          echo "Reading profile '$profile'"
+        echo "Reading profile '$profile'"
+        new_priority=$(
           source "$PROFILE_DIR/$profile"
-          [[ "$Interface" == "$1" && "$Connection" == "ethernet" ]] || continue
-          is_yes "${AutoWired:-no}" && exit 1 # user preferred AUTO profile
-          [[ "$IP" == "dhcp" ]] && exit 2 # dhcp profile
-          exit 3 # static profile
+          [[ "$Interface" == "$1" && "$Connection" == "ethernet" ]] || exit 1
+          is_yes "${ExcludeAuto:-no}" && exit 1
+          : ${Priority:=0}
+
+          echo "$Priority"
+          exit 0
         )
-        case $? in
-          1) preferred_profiles+=("$profile");;
-          2) dhcp_profiles+=("$profile");;
-          3) static_profiles+=("$profile");;
-        esac
+        if (( $? == 0 )); then
+            if [[ -z $selected ]] || (( new_priority >= priority )); then
+                selected=$profile
+                priority=$new_priority
+            fi
+        fi
     done < <(list_profiles)
-    if [[ ${#preferred_profiles[@]} > 1 ]]; then
-        echo "AutoWired flag for '$1' set in more than one profile (${preferred_profiles[*]})"
-    fi
-    for profile in "${preferred_profiles[@]}" "${dhcp_profiles[@]}" "${static_profiles[@]}"; do
-        if ForceConnect=yes "$SUBR_DIR/network" start "$profile"; then
+    if [[ $selected ]]; then
+        if ForceConnect=yes "$SUBR_DIR/network" start "$selected"; then
             mkdir -p "$(dirname "$PROFILE_FILE")"
-            printf "%s" "$profile" > "$PROFILE_FILE"
+            printf "%s" "$selected" > "$PROFILE_FILE"
             exit 0
         fi
-    done
+    fi
   ;;
   down)
     if [[ -e "$PROFILE_FILE" ]]; then
-        if ForceConnect=yes "$SUBR_DIR/network" stop "$(< "$PROFILE_FILE")"; then
-            rm -f "$PROFILE_FILE"
-            exit 0
-        fi
+        profile=$(< "$PROFILE_FILE")
+        "$SUBR_DIR/network" stop "$profile"
+        rm -f "$PROFILE_FILE"
+        exit 0
     fi
   ;;
   *)


### PR DESCRIPTION
Wired profiles can use `Priority` and `ExcludeAuto` to determine automatic profile selection like for wireless profiles.