### PR TITLE
Use netctl-auto for profile switching

### DIFF
--- a/src/wifi-menu
+++ b/src/wifi-menu
@@ -181,10 +181,11 @@ connect_to_ssid()
     if systemctl is-active --quiet "netctl-auto@$INTERFACE.service"; then
         report_notice "Interface '$INTERFACE' is controlled by netctl-auto"
         if (( NEW_PROFILE )); then
+            report_notice "Restart netctl-auto to activate new profile"
             do_debug systemctl restart "netctl-auto@$INTERFACE.service"
-        else
-            report_error "A profile already exists for SSID '$1'"
         fi
+        report_notice "Switch to $PROFILE using netctl-auto"
+        do_debug netctl-auto switch-to $PROFILE
     elif ! netctl switch-to "$PROFILE"; then
         if (( NEW_PROFILE )); then
             msg="         CONNECTING FAILED


### PR DESCRIPTION
If an interface is managed via netctl-auto use netctl-auto
to switch the profile instead of failing