### PR TITLE
Gracefully remove interfaces from dhcpcd.

### DIFF
--- a/src/lib/dhcp/dhcpcd
+++ b/src/lib/dhcp/dhcpcd
@@ -20,7 +20,7 @@ dhcpcd_start() {
 }
 
 dhcpcd_stop() {
-    local stop="-x"
+    local stop="-k"
     if [[ -f "/run/dhcpcd-$Interface-$1.pid" ]]; then
         is_yes "${DHCPReleaseOnStop:-no}" && stop="-k"
         do_debug dhcpcd -$1 -q $stop "$Interface" > /dev/null


### PR DESCRIPTION
Instead of just telling dhcpcd to kill itself, we shall tell dhcpcd
to deconfigure the interface and die if not needed anymore.

With the -x option we tell dhcpcd to "Exit", which will lead to following behaviour:
- Shutdown all managed devices
- Run "only" the STOPPED hook

The default hook handling script will then do nothing. This will leave all entries in the resolv.conf.
Furthermore if you have multiple devices handled by dhcpcd shutting down one profile will render them all useless. 
