### PR TITLE
mobile_ppp: do not call CGDCONT if AccessPointName is not set.

### DIFF
--- a/src/lib/connections/mobile_ppp
+++ b/src/lib/connections/mobile_ppp
@@ -64,7 +64,7 @@ TIMEOUT 3
   GPRSonly) printf "\^SYSCFG=13,1,3fffffff,0,0";;
   GPRSpref) printf "\^SYSCFG=2,1,3fffffff,0,0";;
 esac)'
-'OK-AT-OK' 'AT+CGDCONT=1,"IP",$(quote_word "$AccessPointName")'
+${AccessPointName:'OK-AT-OK' 'AT+CGDCONT=1,"IP",$(quote_word "$AccessPointName")'}
 'OK' 'ATDT${PhoneNumber:-*99#}'
 TIMEOUT 30
 CONNECT ''


### PR DESCRIPTION
Some mobile does not use APN to connect, this commit allow connection
established with empty APN.