### PR TITLE
Redirect wpa_supplicant output in wpa_start() (closes #112)

### DIFF
--- a/src/lib/wpa
+++ b/src/lib/wpa
@@ -80,7 +80,7 @@ wpa_start() {
     fi
 
     do_debug wpa_supplicant -B -P "$pidfile" -i "$interface" -D "$driver" \
-                            "$configuration" $WPAOptions
+                            "$configuration" $WPAOptions > /dev/null
 
     # Wait up to one second for the pid file to appear
     if ! timeout_wait 1 '[[ -f $pidfile ]]'; then


### PR DESCRIPTION
wpa_supplicant>=2.4 sets stdout to be line-buffered. This breaks
wpa_supplicant_scan() since the startup message from wpa_supplicant
("Successfully initialized wpa_supplicant") gets printed before the
essids filename.