### PR TITLE
Support custom chat send messages for mobile

### DIFF
--- a/docs/examples/mobile_ppp
+++ b/docs/examples/mobile_ppp
@@ -20,3 +20,7 @@ AccessPointName=apn
 # Mode can be one of 3Gpref, 3Gonly, GPRSpref, GPRSonly, None
 # These only work for Huawei USB modems; all other devices should use None
 Mode=3Gpref
+
+# Chat send strings
+# Init1=ATZ
+# Init2=ATQ0 V1 E1 S0=0 &C1 &D2 +FCLASS=0

--- a/src/lib/connections/mobile_ppp
+++ b/src/lib/connections/mobile_ppp
@@ -51,13 +51,13 @@ ABORT   '\nRINGING\r\n\r\nRINGING\r'
 REPORT CONNECT
 TIMEOUT 6
 '' 'ATQ0'
-'OK-AT-OK' 'ATZ'
+'OK-AT-OK' '${Init1:-ATZ}'
 TIMEOUT 3
 'OK' 'AT+CFUN=1'
 'OK' 'AT${Pin:++CPIN=$(quote_word "$Pin")}'
 'OK\d-AT-OK' 'ATI'
-'OK' 'ATZ'
-'OK' 'ATQ0 V1 E1 S0=0 &C1 &D2 +FCLASS=0'
+'OK' '${Init1:-ATZ}'
+'OK' '${Init2:-ATQ0 V1 E1 S0=0 &C1 &D2 +FCLASS=0}'
 'OK' 'AT$(case $Mode in
   3Gonly) printf "\^SYSCFG=14,2,3fffffff,0,1";;
   3Gpref) printf "\^SYSCFG=2,2,3fffffff,0,1";;


### PR DESCRIPTION
The ppp chat messages need to be customized for some services/devices.
For example: With my device, the Init2 message needs to be

    `ATQ0 V1 E1 S0=0`

to get a successful connection.

The Init1 and Init2 nomenclature is borrowed from [wvdial][].

[wvdial]: https://wiki.archlinux.org/index.php/Wvdial