### PR TITLE
Support non-ASCII ESSID

### DIFF
--- a/src/lib/wpa
+++ b/src/lib/wpa
@@ -247,7 +247,11 @@ wpa_make_config_block() {
       ;;
     esac
 
-    echo "ssid=$(wpa_quote "$ESSID")"
+    if [[ $ESSID == \"* ]]; then
+        echo "ssid=${ESSID:1}"
+    else
+        echo "ssid=$(echo -n "$ESSID" | hexdump -ve '/1 "%02x"')"
+    fi
     [[ $AP ]] && echo "bssid=${AP,,}"
     is_yes "${Hidden:-no}" && echo "scan_ssid=1"
     is_yes "${AdHoc:-no}" && echo "mode=1"

--- a/src/wifi-menu
+++ b/src/wifi-menu
@@ -67,6 +67,7 @@ init_entries()
 {
     local i=0 flags signal ssid
     while IFS=$'\t' read -r signal flags ssid; do
+        ssid=$(echo -ne "$ssid")
         ENTRIES[i++]="--"  # $ssid might look like an option to dialog.
         ENTRIES[i++]=$ssid
         if in_array "$ssid" "${ESSIDS[@]}"; then
@@ -122,11 +123,16 @@ Do you want to overwrite it?"
 # Creates a profile for ssid $1.
 create_profile()
 {
-    local box flags key msg security
+    local box flags key msg security signal_ flags_ ssid_
     PROFILE="$INTERFACE-${1//\//_}"
     [[ -e "$PROFILE_DIR/$PROFILE" ]] && PROFILE+=".wifi-menu"
     confirm_profile || return $?
-    flags=$(grep -m 1 $'\t'"$1\$" "$NETWORKS" | cut -f 2)
+    while IFS=$'\t' read -r signal_ flags_ ssid_; do
+        if [[ "$(echo -ne "$ssid_")" = "$1" ]]; then
+            flags=$flags_
+            break
+        fi
+    done < "$NETWORKS"
     if [[ "$flags" =~ WPA|WEP ]]; then
         security=${BASH_REMATCH[0],,}
     else
@@ -183,7 +189,7 @@ connect_to_ssid()
         if (( NEW_PROFILE )); then
             do_debug systemctl restart "netctl-auto@$INTERFACE.service"
         fi
-        do_debug netctl-auto switch-to $PROFILE
+        do_debug netctl-auto switch-to "$PROFILE"
     elif ! netctl switch-to "$PROFILE"; then
         if (( NEW_PROFILE )); then
             msg="         CONNECTING FAILED
@@ -252,7 +258,7 @@ if [[ "$RFKill" && "$(rf_status "$INTERFACE" "$RFKill")" ]]; then
 fi
 
 echo -n "Scanning for networks... "
-CONNECTION=$(wpa_call "$INTERFACE" status 2> /dev/null | sed -n "s/^ssid=//p")
+CONNECTION=$(echo -ne $(wpa_call "$INTERFACE" status 2> /dev/null | sed -n "s/^ssid=//p"))
 NETWORKS=$(wpa_supplicant_scan "$INTERFACE" 3,4,5)
 RETURN=$?
 


### PR DESCRIPTION
This patch adds support for ESSID containing non-ASCII characters.

`wpa_cli`'s output is encoded in [this way](https://w1.fi/cgit/hostap/tree/src/utils/common.c?id=f43c1ae7989c38fe15756f12a9196a1cf798b4d7#n466) and this can be decoded with `echo -ne "$string"`.
