### PR TITLE
Allow multiple bond devices with different values

### DIFF
--- a/src/lib/connections/bond
+++ b/src/lib/connections/bond
@@ -22,8 +22,10 @@ bond_up() {
         ip link set dev "$slave" master "$Interface"
     done
  
+    #detect sysfs if directory present assume sysfs
     if [ -d /sys/class/net ]
      then
+     #iterate though possible multi-value parameters and assign value to this bond instance on match
      for var in arp_ip_target
       do
       list="$var[@]"
@@ -33,7 +35,7 @@ bond_up() {
        done
       done
 
-     #all single value options execpt for mode
+     #iterate though possible single value parameters and assign value to this bond instance on match
      for var in active_slave ad_actor_key ad_aggregator ad_num_ports ad_partner_key ad_partner_mac ad_select all_slaves_active arp_interval arp_validate downdelay fail_over_mac lacp_rate lp_interval mii_status miimon min_links num_grat_arp num_unsol_na packets_per_slave primary primary_reselect queue_id resend_igmp slaves tlb_dynamic_lb updelay use_carrier xmit_hash_policy
       do
       val=${!var}

--- a/src/lib/connections/bond
+++ b/src/lib/connections/bond
@@ -1,4 +1,5 @@
 # Contributed by: andy123 <ajs@online.de>
+# modified by: gpomega <gerald@palmerhouse.net>
 
 . "$SUBR_DIR/ip"
 
@@ -12,10 +13,36 @@ bond_up() {
     fi
 
     interface_add bond "$Interface" "" ${Mode:+mode "$Mode"}
+    if [ -n "$Mode" ]
+     then
+     echo "$Mode" >/sys/class/net/$Interface/bonding/mode
+     fi
     bring_interface_up "$Interface"
     for slave in "${BindsToInterfaces[@]}"; do
         ip link set dev "$slave" master "$Interface"
     done
+ 
+    if [ -d /sys/class/net ]
+     then
+     for var in arp_ip_target
+      do
+      list="$var[@]"
+      for member in ${!list}
+       do
+       echo +$member>/sys/class/net/$Interface/bonding/$var
+       done
+      done
+
+     #all single value options execpt for mode
+     for var in active_slave ad_actor_key ad_aggregator ad_num_ports ad_partner_key ad_partner_mac ad_select all_slaves_active arp_interval arp_validate downdelay fail_over_mac lacp_rate lp_interval mii_status miimon min_links num_grat_arp num_unsol_na packets_per_slave primary primary_reselect queue_id resend_igmp slaves tlb_dynamic_lb updelay use_carrier xmit_hash_policy
+      do
+      val=${!var}
+      if [ -n "$val" ]
+       then
+       echo "$val" >/sys/class/net/$Interface/bonding/$var
+       fi
+      done
+     fi
 
     ip_set
 }


### PR DESCRIPTION
Cannot create multiple bond devices with different characteristics.  This is really important for arp_validation and quick failover on bond interfaces

EG 
bond0 with: 
>arp_ip_target 192.168.0.1
>arp_interval=500
 
bond1 with 
>arp_ip_target 192.168.255.1,192.168.255.254
>arp_interval=200

see issue#120 for full problem and explanation
[https://github.com/joukewitteveen/netctl/issues/120](url)

This code only works with sysfs

a full configuration for bond0:
```
Description="Bond to user land"
Interface=bond0
Connection=bond
BindsToInterfaces=(enp5s0 enp2s0f0)
Mode=active-backup
IPV6=no
IP=no

>arp_ip_target=(192.168.12.10 192.168.12.14)
>arp_validate=all
>arp_interval=200
>primary=enp5s0
```
bond1:
```
Description="Bond to outside"
Interface=bond1
Connection=bond
BindsToInterfaces=(eno1 enp2s0f1)
Mode=active-backup
IPV6=no
IP=no

arp_ip_target=(192.168.0.4 192.168.0.1)
arp_validate=all
arp_interval=100
primary=eno1
```