### PR TITLE
services: use escaped profile names

### DIFF
--- a/services/netctl-auto@.service
+++ b/services/netctl-auto@.service
@@ -7,8 +7,8 @@ Before=network.target
 Wants=network.target
 
 [Service]
-ExecStart=/usr/bin/netctl-auto start %I
-ExecStop=/usr/bin/netctl-auto stop %I
+ExecStart=/usr/bin/netctl-auto start %i
+ExecStop=/usr/bin/netctl-auto stop %i
 RemainAfterExit=yes
 Type=forking
 

--- a/services/netctl-ifplugd@.service
+++ b/services/netctl-ifplugd@.service
@@ -5,7 +5,7 @@ BindsTo=sys-subsystem-net-devices-%i.device
 After=sys-subsystem-net-devices-%i.device network-pre.target
 
 [Service]
-ExecStart=/usr/bin/ifplugd -i %I -r /etc/ifplugd/netctl.action -bfIns
+ExecStart=/usr/bin/ifplugd -i %i -r /etc/ifplugd/netctl.action -bfIns
 
 [Install]
 WantedBy=multi-user.target

--- a/services/netctl@.service
+++ b/services/netctl@.service
@@ -8,5 +8,5 @@ Wants=network.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/lib/network/network start %I
-ExecStop=/usr/lib/network/network stop %I
+ExecStart=/usr/lib/network/network start %i
+ExecStop=/usr/lib/network/network stop %i


### PR DESCRIPTION
My wifi network contains ' (single quota) in name.
When I connect with wifi-menu to my network, I get:
Warning: netctl@wlan0\x2dOctopus\x27s\x20Garden.service changed on disk. Run 'systemctl daemon-reload' to reload units.
Failed to start netctl@wlan0\x2dOctopus\x27s\x20Garden.service: Unit netctl@wlan0\x2dOctopus\x27s\x20Garden.service is not loaded properly: Invalid argument.
See system logs and 'systemctl status netctl@wlan0\x2dOctopus\x27s\x20Garden.service' for details.

While `systemctl status` gives nothing, system log contains:
systemd[1]: netctl@wlan0\x2dOctopus\x27s\x20Garden.service: Service lacks both ExecStart= and ExecStop= setting. Refusing.

This patch converts %I which is unescaped instance name to %i, which
is escaped (see man systemd.unit(5)).

Signed-off-by: Dmitry Safonov <0x7f454c46@gmail.com>