### PR TITLE
Add descriptive solution to netctl-auto error

### DIFF
--- a/src/wifi-menu
+++ b/src/wifi-menu
@@ -183,7 +183,7 @@ connect_to_ssid()
     fi
     clear
     if systemctl is-active --quiet "netctl-auto@$INTERFACE.service"; then
-        report_notice "Interface '$INTERFACE' is controlled by netctl-auto"
+        report_notice "Interface '$INTERFACE' is controlled by netctl-auto. Try running 'systemctl restart netctl-auto@$INTERFACE.service' to use the new profile."
         if is_yes "${NEW_PROFILE:-no}"; then
             do_debug systemctl restart "netctl-auto@$INTERFACE.service"
         fi


### PR DESCRIPTION
The "$INTERFACE is controlled by netctl-auto" error results after running wifi-menu, creating a new profile, and failing to alert netctl of the new profile.

This approach works every time for my system, to the point that you may even want to do it automatically, and print that the script is trying to reconnect via netctl-auto. 

In lieu of any automatic solutions to this minor issue, it would be better to have a more descriptive error.