### PR TITLE
Add dhcpcd support for IPv4LL, fix mistake in dhcp/README

### DIFF
--- a/src/lib/dhcp/README
+++ b/src/lib/dhcp/README
@@ -5,7 +5,7 @@ Support for dhcp clients is implemented by files in
 The file name determines the name of the client for the profile, so
 support for a client named dhcpcd is provided by the file:
 
-  /usr/lib/network/connections/dhcpcd
+  /usr/lib/network/dhcp/dhcpcd
 
 Files that implement support for a connection type should NOT be
 executable. Such files should contain valid Bash code, among which two

--- a/src/lib/dhcp/dhcpcd
+++ b/src/lib/dhcp/dhcpcd
@@ -3,7 +3,7 @@ type dhcpcd &> /dev/null || return
 dhcpcd_start() {
     local options
     case $1 in
-      4) options="$DhcpcdOptions -L";;
+      4) options=$DhcpcdOptions;;
       6) options=$DhcpcdOptions6;;
       *) return 1;;
     esac


### PR DESCRIPTION
Fixes https://github.com/joukewitteveen/netctl/issues/109

If I wrote more here, I would just be duplicating the commit messages.