### PR TITLE
Add Syscfg config line for mobile_ppp connections

### DIFF
--- a/docs/examples/mobile_ppp
+++ b/docs/examples/mobile_ppp
@@ -19,4 +19,5 @@ AccessPointName=apn
 
 # Mode can be one of 3Gpref, 3Gonly, GPRSpref, GPRSonly, None
 # These only work for Huawei USB modems; all other devices should use None
+# If Mode is set to SYSCFG=..., a custom AT^SYSCFG line is sent instead.
 Mode=3Gpref

--- a/docs/netctl.profile.5.txt
+++ b/docs/netctl.profile.5.txt
@@ -438,7 +438,8 @@ type:
     This option is used to specify the connection mode. Can be one of
     `3Gpref', `3Gonly', `GPRSpref', `GPRSonly', `None'. This generates
     AT commands specific to certain Huawei modems; all other devices
-    should use `None'.
+    should use `None'. If `Mode` is set to `SYSCFG=...`, a custom
+    `AT^SYSCFG` line is sent instead.
 
 'Init='::
     An initialization string sent to the modem before dialing. This

--- a/src/lib/connections/mobile_ppp
+++ b/src/lib/connections/mobile_ppp
@@ -43,6 +43,8 @@ TIMEOUT 3
   3Gpref) printf "\^SYSCFG=2,2,3fffffff,0,1";;
   GPRSonly) printf "\^SYSCFG=13,1,3fffffff,0,0";;
   GPRSpref) printf "\^SYSCFG=2,1,3fffffff,0,0";;
+  SYSCFG=*) printf "\^$Mode";;
+  # If set to "None", this is a no-op
 esac)'
 ${AccessPointName:+'OK-AT-OK' 'AT+CGDCONT=1,$(quote_word "IP"),$(quote_word "$AccessPointName")'}
 'OK' 'ATDT${PhoneNumber:-*99#}'


### PR DESCRIPTION
This makes it possible to set more modem-specific options, e.g. to turn on roaming.