### PR TITLE
Fix: IPCP: timeout sending Config-Requests

### DIFF
--- a/docs/examples/mobile_ppp
+++ b/docs/examples/mobile_ppp
@@ -23,7 +23,7 @@ AccessPointName=apn
 Mode=3Gpref
 
 # If pppd should request '0.0.0.0' during IPCP negotiation (default: no)
-# If set to 'no' pppd requests the IP addressess of *any* other interface
+# If set to 'no', pppd requests the IP address of *any* other interface
 # in the ConfReq during IPCP negotiation. Some providers silently ignore
 # those requests and you might experience 'IPCP: timeout sending Config-Requests'.
 # By enabling this, option 'noipdefault' is passed to pppd.

--- a/docs/examples/mobile_ppp
+++ b/docs/examples/mobile_ppp
@@ -21,3 +21,10 @@ AccessPointName=apn
 # If Mode is set to SYSCFG=..., a custom AT^SYSCFG=... line is sent
 # This setting is for Huawei USB modems; all other devices should use None
 Mode=3Gpref
+
+# If pppd should request any of your currently assigned IP addressess (default: no)
+# pppd requests the IP addressess of *any* other interface in the ConfReq
+# during IPCP negotiation. Some providers silently ignore those requests and
+# you might experience 'IPCP: timeout sending Config-Requests'.
+# By enabling this, option 'noipdefault' is set. This results in '0.0.0.0' being requested.
+ConfReqAnyAddr=yes

--- a/docs/examples/mobile_ppp
+++ b/docs/examples/mobile_ppp
@@ -22,9 +22,9 @@ AccessPointName=apn
 # This setting is for Huawei USB modems; all other devices should use None
 Mode=3Gpref
 
-# If pppd should request any of your currently assigned IP addressess (default: no)
-# pppd requests the IP addressess of *any* other interface in the ConfReq
-# during IPCP negotiation. Some providers silently ignore those requests and
-# you might experience 'IPCP: timeout sending Config-Requests'.
-# By enabling this, option 'noipdefault' is set. This results in '0.0.0.0' being requested.
+# If pppd should request '0.0.0.0' during IPCP negotiation (default: no)
+# If set to 'no' pppd requests the IP addressess of *any* other interface
+# in the ConfReq during IPCP negotiation. Some providers silently ignore
+# those requests and you might experience 'IPCP: timeout sending Config-Requests'.
+# By enabling this, option 'noipdefault' is passed to pppd.
 ConfReqAnyAddr=yes

--- a/src/lib/connections/mobile_ppp
+++ b/src/lib/connections/mobile_ppp
@@ -64,7 +64,7 @@ modem
 passive
 novj
 holdoff 10
-noipdefault
+$(is_yes "${ConfReqAnyAddr:-no}" && printf noipdefault)
 
 noauth
 $(is_yes "${DefaultRoute:-yes}" || printf no)defaultroute

--- a/src/lib/connections/mobile_ppp
+++ b/src/lib/connections/mobile_ppp
@@ -64,6 +64,7 @@ modem
 passive
 novj
 holdoff 10
+noipdefault
 
 noauth
 $(is_yes "${DefaultRoute:-yes}" || printf no)defaultroute


### PR DESCRIPTION
According to [the docs](https://www.tldp.org/HOWTO/PPP-HOWTO/options.html#AEN964), pppd will try to determine the local IP address and include it in the IPCP ConfReq. This leads to any local IP being sent in the request as seen in journalctl (added `debug dump logfd 2` too):

```
Okt 17 10:21:59 arch-x230 pppd[13514]: sent [CCP ConfReq id=0x1 <deflate 15> <deflate(old#) 15> <bsd v1 15>]
Okt 17 10:21:59 arch-x230 pppd[13514]: sent [IPCP ConfReq id=0x1 <addr 192.168.10.13> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
Okt 17 10:21:59 arch-x230 pppd[13514]: rcvd [LCP EchoRep id=0x0 magic=0x5e049130]
Okt 17 10:21:59 arch-x230 pppd[13514]: rcvd [LCP ProtRej id=0x1 80 fd 01 01 00 0f 1a 04 78 00 18 04 78 00 15 03 2f]
Okt 17 10:21:59 arch-x230 pppd[13514]: Protocol-Reject for 'Compression Control Protocol' (0x80fd) received
Okt 17 10:22:02 arch-x230 pppd[13514]: sent [IPCP ConfReq id=0x1 <addr 192.168.10.13> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
Okt 17 10:22:05 arch-x230 pppd[13514]: sent [IPCP ConfReq id=0x1 <addr 192.168.10.13> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
Okt 17 10:22:08 arch-x230 pppd[13514]: sent [IPCP ConfReq id=0x1 <addr 192.168.10.13> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
Okt 17 10:22:12 arch-x230 pppd[13514]: sent [IPCP ConfReq id=0x1 <addr 192.168.10.13> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
Okt 17 10:22:15 arch-x230 pppd[13514]: sent [IPCP ConfReq id=0x1 <addr 192.168.10.13> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
Okt 17 10:22:18 arch-x230 pppd[13514]: sent [IPCP ConfReq id=0x1 <addr 192.168.10.13> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
Okt 17 10:22:21 arch-x230 pppd[13514]: sent [IPCP ConfReq id=0x1 <addr 192.168.10.13> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
Okt 17 10:22:24 arch-x230 pppd[13514]: sent [IPCP ConfReq id=0x1 <addr 192.168.10.13> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
Okt 17 10:22:27 arch-x230 pppd[13514]: sent [IPCP ConfReq id=0x1 <addr 192.168.10.13> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
Okt 17 10:22:29 arch-x230 pppd[13514]: sent [LCP EchoReq id=0x1 magic=0xe4aa7389]
Okt 17 10:22:29 arch-x230 pppd[13514]: rcvd [LCP EchoRep id=0x1 magic=0x5e049130]
Okt 17 10:22:30 arch-x230 pppd[13514]: IPCP: timeout sending Config-Requests
```

As you can see, some providers won't reply with a IPCP ConfNak, so this times out and no IP is assigned. I'm on Vodafone.de.

This PR disables the default behaviour and will include `0.0.0.0` in the IPCP ConfReq:
```
Okt 17 10:33:58 arch-x230 pppd[13893]: sent [CCP ConfReq id=0x1 <deflate 15> <deflate(old#) 15> <bsd v1 15>]
Okt 17 10:33:58 arch-x230 pppd[13893]: sent [IPCP ConfReq id=0x1 <addr 0.0.0.0> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
Okt 17 10:33:58 arch-x230 pppd[13893]: rcvd [LCP EchoRep id=0x0 magic=0x5546a71e]
Okt 17 10:33:58 arch-x230 pppd[13893]: rcvd [LCP ProtRej id=0x1 80 fd 01 01 00 0f 1a 04 78 00 18 04 78 00 15 03 2f]
Okt 17 10:33:58 arch-x230 pppd[13893]: Protocol-Reject for 'Compression Control Protocol' (0x80fd) received
Okt 17 10:34:00 arch-x230 pppd[13893]: rcvd [IPCP ConfReq id=0x1]
Okt 17 10:34:00 arch-x230 pppd[13893]: sent [IPCP ConfNak id=0x1 <addr 0.0.0.0>]
Okt 17 10:34:00 arch-x230 pppd[13893]: rcvd [IPCP ConfNak id=0x1 <addr 10.165.250.24> <ms-dns1 62.109.121.17> <ms-dns2 62.109.121.18>]
Okt 17 10:34:00 arch-x230 pppd[13893]: sent [IPCP ConfReq id=0x2 <addr 10.165.250.24> <ms-dns1 62.109.121.17> <ms-dns2 62.109.121.18>]
Okt 17 10:34:00 arch-x230 pppd[13893]: rcvd [IPCP ConfReq id=0x2]
Okt 17 10:34:00 arch-x230 pppd[13893]: sent [IPCP ConfAck id=0x2]
Okt 17 10:34:00 arch-x230 pppd[13893]: rcvd [IPCP ConfAck id=0x2 <addr 10.165.250.24> <ms-dns1 62.109.121.17> <ms-dns2 62.109.121.18>]
Okt 17 10:34:00 arch-x230 pppd[13893]: Could not determine remote IP address: defaulting to 10.64.64.64
Okt 17 10:34:00 arch-x230 pppd[13893]: not replacing existing default route via 192.168.10.1
Okt 17 10:34:00 arch-x230 pppd[13893]: Cannot determine ethernet address for proxy ARP
Okt 17 10:34:00 arch-x230 pppd[13893]: local  IP address 10.165.250.24
Okt 17 10:34:00 arch-x230 pppd[13893]: remote IP address 10.64.64.64
Okt 17 10:34:00 arch-x230 pppd[13893]: primary   DNS address 62.109.121.17
Okt 17 10:34:00 arch-x230 pppd[13893]: secondary DNS address 62.109.121.18
```


Signed-off-by: Christoph Hoopmann <christophhoopmann@gmail.com>