### PR TITLE
Interface config in combination with netctl-auto

### DIFF
--- a/src/lib/dhcp/dhcpcd
+++ b/src/lib/dhcp/dhcpcd
@@ -2,6 +2,7 @@ type dhcpcd &> /dev/null || return
 
 dhcpcd_start() {
     local options
+    load_interface_config "$Interface"
     case $1 in
       4) options=${DhcpcdOptions-"-L"};;
       6) options=$DhcpcdOptions6;;

--- a/src/netctl-auto
+++ b/src/netctl-auto
@@ -215,6 +215,7 @@ start() {
         report_debug "Examining profile '$profile'"
         (
           source "$PROFILE_DIR/$profile"
+          load_interface_config "$Interface"
           [[ $Interface == "$interface" && $Connection == "wireless" ]] || exit
           is_yes "${ExcludeAuto:-no}" && exit
           # Set default and exclude wpa-config as it does not fit this scheme


### PR DESCRIPTION
In profiles it is possible to define a interface script which sets the `$Interface` variable. This enables us to create scripts to return 'any' interface instead of a fixed one. 
An example can be seen here:
[ArchWiki netctl](https://wiki.archlinux.org/index.php/netctl#Using_any_interface)

A logical step forward would be to use these profiles with netctl-auto. Unfortenately this was not possible because interfaces are only interpreted as fixed interfaces in netctl-auto. This PR attempts to change this.

I was not able to find the exact spot where wpa_supplicant passes the interface to dhcpcd. Therefore, i made dhcpcd interpret the interface while actually the correct interface should be passed in the first place. (See the second commit)