### PR TITLE
Addressing issue #111

### DIFF
--- a/docs/examples/bridge
+++ b/docs/examples/bridge
@@ -3,5 +3,7 @@ Interface=br0
 Connection=bridge
 BindsToInterfaces=(eth0 eth1 tap0)
 IP=dhcp
+## Use the MAC address of a specific interface
+#MACAddressOf=eth1
 ## Ignore (R)STP and immediately activate the bridge
 #SkipForwardingDelay=yes

--- a/docs/netctl.profile.5.txt
+++ b/docs/netctl.profile.5.txt
@@ -348,6 +348,11 @@ connections of the `bridge' type:
     Additional options to be passed to *ip link*. Run
     *ip link add type bridge help* to see the available options.
 
+'MACAddressOf='::
+    Use the MAC address of the optionally specified interface. This can
+    be useful if the network uses MAC address filtering or there are
+    MAC-based DHCP leases needing to be maintained.
+
 
 OPTIONS FOR `dummy' CONNECTIONS
 -------------------------------

--- a/src/lib/connections/bridge
+++ b/src/lib/connections/bridge
@@ -6,6 +6,15 @@
 BindsToInterfaces=("${BindsToInterfaces[@]}")
 
 bridge_up() {
+    if [[ $MACAddressOf ]]; then
+      if is_interface "$MACAddressOf"; then
+        IPCustom+=('link set dev "'$Interface'" address "'$(< /sys/class/net/$MACAddressOf/address)'"')
+      else
+        report_error "Interface '$MACAddressOf' does not exist"
+        return 1
+      fi
+    fi
+
     if is_interface "$Interface"; then
         if [[ ! -d "/sys/class/net/$Interface/brif" ]]; then
             report_error "Interface '$Interface' already exists and is not a bridge"


### PR DESCRIPTION
Added optional configuration variable for maintaining the MAC address of a particular interface in a bridge connection.

I.E.:
```
MACAddressOf=eth1
```