### PR TITLE
Add WireGuard support

### DIFF
--- a/contrib/PKGBUILD.in
+++ b/contrib/PKGBUILD.in
@@ -17,6 +17,7 @@ optdepends=('dialog: for the menu based wifi assistant'
             'ifplugd: for automatic wired connections through netctl-ifplugd'
             'ppp: for PPP connections'
             'openvswitch: for Open vSwitch connections'
+            'wireguard-tools: for WireGuard connections'
            )
 install=netctl.install
 source=(https://sources.archlinux.org/other/packages/netctl/netctl-${pkgver}.tar.xz{,.sig})

--- a/docs/examples/wireguard
+++ b/docs/examples/wireguard
@@ -1,0 +1,11 @@
+Description="Example WireGuard tunnel connection"
+Interface=wg0
+Connection=wireguard
+ConfigFile=/etc/wireguard/wg0.conf
+
+## Example IP configuration
+#IP=static
+#Address=('10.0.0.2/24')
+#
+#IP6=static
+#Address6=('fd00::2/120')

--- a/docs/netctl.profile.5.txt
+++ b/docs/netctl.profile.5.txt
@@ -62,6 +62,8 @@ AVAILABLE CONNECTION TYPES
     For VLANs on ethernet-like connections.
 +macvlan+::
     For MACVLANs on ethernet-like connections.
++wireguard+::
+	For WireGuard interfaces.
 
 
 GENERAL OPTIONS
@@ -546,6 +548,17 @@ following are understood for connections of the `macvlan' type:
 
 'MACAddress='::
     Optional static MAC address for the `macvlan' type link.
+
+
+OPTIONS FOR `wireguard' CONNECTIONS
+-----------------------------------
+The name of the WireGuard interface is specified in 'Interface='. Next
+to the *ip options*, the following are understood for connections of
+the `wireguard' type:
+
+'ConfigFile='::
+    Path to a *WireGuard* configuration file. Defaults to
+    '/etc/wireguard/$Interface.conf'.
 
 
 SPECIAL QUOTING RULES

--- a/src/lib/connections/wireguard
+++ b/src/lib/connections/wireguard
@@ -1,0 +1,30 @@
+# Contributed by: Thibaut Sautereau (thithib) <thibaut at sautereau dot fr>
+
+. "$SUBR_DIR/ip"
+
+wireguard_up() {
+    if is_interface "$Interface"; then
+        report_error "Interface '$Interface' already exists"
+        return 1
+    fi
+
+    interface_add wireguard "$Interface"
+    if ! is_interface "$Interface"; then
+        # This check should be removed once WireGuard support lands in the Arch
+        # Linux kernel. Alternatively, we could add 'WIREGUARD-MODULE' to the
+        # PKGBUILD optdepends?
+        report_error "Interface '$Interface' could not be created. Please make sure your running kernel supports WireGuard."
+        return 1
+    fi
+
+    wg setconf "$Interface" "${ConfigFile:-/etc/wireguard/$Interface.conf}"
+    ip_set
+    bring_interface_up "$Interface"
+}
+
+wireguard_down() {
+    ip_unset
+    interface_delete "$Interface"
+}
+
+# vim: ft=sh ts=4 et sw=4:

--- a/src/lib/connections/wireguard
+++ b/src/lib/connections/wireguard
@@ -18,8 +18,8 @@ wireguard_up() {
     fi
 
     wg setconf "$Interface" "${ConfigFile:-/etc/wireguard/$Interface.conf}"
-    ip_set
     bring_interface_up "$Interface"
+    ip_set
 }
 
 wireguard_down() {


### PR DESCRIPTION
Hello,

Not sure many people need that in addition to what can already be done with **wg-quick(8)**, but I quickly put together support for **WireGuard interfaces**. I find it useful to handle this with netctl, as I can more easily integrate my use of WireGuard with the other network interfaces I need.

Please tell me what you think about such a feature ([here](https://github.com/thithib/netctl-wg_PKGBUILD) is a PKGBUILD if you want to try it out), and I hope it will prove useful to some people ;)