### PR TITLE
Fix issue with netctl-auto not seeing any profiles

### DIFF
--- a/src/netctl-auto
+++ b/src/netctl-auto
@@ -30,7 +30,7 @@ END
 list_netctl_auto_interfaces() {
     systemctl --full --no-legend --no-pager \
         --type=service --state=running list-units | \
-        sed -nr 's/^netctl-auto@([[:alnum:]]+).*/\1/p'
+        sed -nr 's/^\s*netctl-auto@([[:alnum:]]+).*/\1/p'
 }
 
 ## List all profiles available to the WPA supplicant


### PR DESCRIPTION
After some update to `systemd`, the command used by `netctl-auto` to locate enabled interfaces - `systemctl ... list-units` - added two whitespaces in the beginning of each line. As a result, the regex used by `netctl-auto` stopped working, and `nectl-auto list` prints nothing. Other `netctl-auto` commands also stop workirng.
This PR fixes that issue.