### PR TITLE
Speed up 'netctl list'

### DIFF
--- a/src/lib/globals
+++ b/src/lib/globals
@@ -144,7 +144,7 @@ sd_call() {
 ## Retrieves the status string from the unit for a profile
 # $1: profile name
 sd_status_text() {
-    sd_call "status --lines=0" "$1" | sed -n 's/^ *Status: "\(.*\)"$/\1/p'
+    sd_call "show --property=StatusText --value" "$1"
 }
 
 

--- a/src/lib/globals
+++ b/src/lib/globals
@@ -144,7 +144,7 @@ sd_call() {
 ## Retrieves the status string from the unit for a profile
 # $1: profile name
 sd_status_text() {
-    sd_call status "$1" | sed -n 's/^ *Status: "\(.*\)"$/\1/p'
+    sd_call "status --lines=0" "$1" | sed -n 's/^ *Status: "\(.*\)"$/\1/p'
 }
 
 


### PR DESCRIPTION
When you call `netctl list`, it calls `systemctl status` for each of the profiles. Then it `sed`s out just a single `Status` field.
But when you call `systemctl status`, it fetches last log entries from `journald` which is often time-consuming operation - see https://github.com/systemd/systemd/issues/2460.

So we should pass `--lines=0` which effectively tells `systemctl` to not ask `journalctl`.