### PR TITLE
[CHANGE-EDITOR]: Change fallback EDITOR from nano to vi

### DIFF
--- a/src/netctl.in
+++ b/src/netctl.in
@@ -178,7 +178,7 @@ case $# in
             systemctl daemon-reload
         fi;;
       edit)
-        exec ${EDITOR:-nano} "$PROFILE_DIR/$2";;
+        exec ${EDITOR:-vi} "$PROFILE_DIR/$2";;
       wait-online)
         wait_online "$2";;
       *)


### PR DESCRIPTION
Most of the systems have no `nano` installed by default.
Personally, I have no `$EDITOR` in my root being set.
Think `vi` would be safer.

Thanks for the cool product <3