### PR TITLE
Manage rosenpass/wireguard setups using Netctl

### DIFF
--- a/contrib/PKGBUILD.in
+++ b/contrib/PKGBUILD.in
@@ -17,6 +17,7 @@ optdepends=('dialog: for the menu based wifi assistant'
             'ppp: for PPP connections'
             'openvswitch: for Open vSwitch connections'
             'wireguard-tools: for WireGuard connections')
+            'rosenpass: for post quantum cryptography wireguard'
 install=netctl.install
 source=(https://sources.archlinux.org/other/packages/netctl/netctl-${pkgver}.tar.xz{,.sig})
 arch=('any')
@@ -34,4 +35,5 @@ package() {
   ln -s netctl "$pkgdir/usr/share/bash-completion/completions/wifi-menu"
   install -D -m644 contrib/zsh-completion "$pkgdir/usr/share/zsh/site-functions/_netctl"
 }
+
 

--- a/contrib/PKGBUILD.in
+++ b/contrib/PKGBUILD.in
@@ -16,8 +16,8 @@ optdepends=('dialog: for the menu based wifi assistant'
             'ifplugd: for automatic wired connections through netctl-ifplugd'
             'ppp: for PPP connections'
             'openvswitch: for Open vSwitch connections'
-            'wireguard-tools: for WireGuard connections')
             'rosenpass: for post quantum cryptography wireguard'
+            'wireguard-tools: for WireGuard connections')
 install=netctl.install
 source=(https://sources.archlinux.org/other/packages/netctl/netctl-${pkgver}.tar.xz{,.sig})
 arch=('any')

--- a/docs/examples/rosenpass
+++ b/docs/examples/rosenpass
@@ -1,0 +1,8 @@
+Description="Rosenpass post quantum cryptography for wireguard"
+Interface=rosenpass0
+Connection=rosenpass
+RosenpassConfig=/home/pi/my/rosenpass-0.2.0/peer-a-config.toml
+
+## Example IP Config
+IP6=static
+Address6=('fe80::1/64')

--- a/src/lib/connections/rosenpass
+++ b/src/lib/connections/rosenpass
@@ -1,0 +1,23 @@
+# Contributed by: Hrushikesh Rao <hrushikesh20thegreat@gmail.com>
+
+. "$SUBR_DIR/ip"
+
+# Make sure BindsToInterfaces is set
+BindsToInterfaces=("${BindsToInterfaces[@]}")
+
+rosenpass_up() {
+    if is_interface "$Interface"; then
+        report_error "Interface '$Interface' already exists"
+        return 1
+    fi
+
+    interface_add wireguard "$Interface" "$MACAddress" || return
+    /root/.cargo/bin/rosenpass exchange-config "$RosenpassConfig"
+    bring_interface_up "$Interface"
+    ip_set
+}
+
+rosenpass_down() {
+    ip_unset
+    bring_interface_down "$Interface" || return 1
+}

--- a/src/lib/connections/rosenpass
+++ b/src/lib/connections/rosenpass
@@ -19,5 +19,5 @@ rosenpass_up() {
 
 rosenpass_down() {
     ip_unset
-    bring_interface_down "$Interface" || return 1
+    interface_delete "$Interface"
 }


### PR DESCRIPTION
The [rosenpass tool](https://github.com/rosenpass/rosenpass/blob/main/src) is written in Rust and uses liboqs[1](https://github.com/rosenpass/rosenpass#user-content-fn-liboqs-50735ab6546df94ed046223a45453c43) and libsodium[2](https://github.com/rosenpass/rosenpass#user-content-fn-libsodium-50735ab6546df94ed046223a45453c43). The tool establishes a symmetric key and provides it to WireGuard. Since it supplies WireGuard with key through the PSK feature using Rosenpass+WireGuard is cryptographically no less secure than using WireGuard on its own ("hybrid security"). Rosenpass refreshes the symmetric key every two minutes.

We want to manage rosenpass/wireguard using Netctl.

References-
Repository - https://github.com/rosenpass/rosenpass
Issue - https://github.com/rosenpass/rosenpass/issues/80


