### PR TITLE
Feature: add linux network namespace support for wireguard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ install:
 	install -d $(DESTDIR)/etc/netctl/{examples,hooks,interfaces}
 	install -m644 docs/examples/* $(DESTDIR)/etc/netctl/examples/
 	# Libs
-	install -Dt $(DESTDIR)/usr/lib/netctl -m644 src/lib/{globals,interface,ip,rfkill,wpa}
+	install -Dt $(DESTDIR)/usr/lib/netctl -m644 src/lib/{globals,interface,ip,rfkill,wpa,namespace}
 	install -Dt $(DESTDIR)/usr/lib/netctl/connections -m644 src/lib/connections/*
 	install -Dt $(DESTDIR)/usr/lib/netctl/dhcp -m644 src/lib/dhcp/*
 	install -m755 src/lib/{auto.action,network} $(DESTDIR)/usr/lib/netctl/

--- a/docs/examples/wireguard
+++ b/docs/examples/wireguard
@@ -2,6 +2,7 @@ Description="Example WireGuard tunnel connection"
 Interface=wg0
 Connection=wireguard
 WGConfigFile=/etc/wireguard/wg0.conf
+# WGNamespace=subnet
 
 ## Example IP configuration
 IP=static

--- a/src/lib/connections/wireguard
+++ b/src/lib/connections/wireguard
@@ -1,26 +1,45 @@
 # Contributed by: Thibaut Sautereau <thibaut@sautereau.fr>
 
 . "$SUBR_DIR/ip"
+. "$SUBR_DIR/namespace"
 
 # Make sure BindsToInterfaces is set
 BindsToInterfaces=("${BindsToInterfaces[@]}")
 
-wireguard_up() {
-    if is_interface "$Interface"; then
-        report_error "Interface '$Interface' already exists"
-        return 1
-    fi
-
-    # Treat $MACAddress as in other connections, but it has no effect here
-    interface_add wireguard "$Interface" "$MACAddress" || return
+wireguard_setconf() {
     wg setconf "$Interface" "${WGConfigFile:-/etc/wireguard/$Interface.conf}"
     bring_interface_up "$Interface"
     ip_set
 }
 
+wireguard_up() {
+    if is_in_namespace "${WGNamespace}"; then
+        wireguard_setconf
+        return 0;
+    elif [[ -n "$WGNamespace" ]]; then
+        # Treat $MACAddress as in other connections, but it has no effect here
+        interface_add wireguard "$Interface" "$MACAddress" || return
+        namespace_add_interface $WGNamespace $Interface
+
+        # Recursion in sub namespace
+        namespace_exec "$WGNamespace" $0 start "$Profile" || return $?
+    elif ! is_interface "$Interface"; then
+        interface_add wireguard "$Interface" "$MACAddress" || return
+        wireguard_setconf
+        return 0
+    else
+        report_error "Interface '$Interface' already exists"
+        return 1
+    fi
+}
+
 wireguard_down() {
-    ip_unset
-    interface_delete "$Interface"
+    if [[ -n "$WGNamespace" ]] && ! is_in_namespace "$WGNamespace"; then
+        namespace_exec "$WGNamespace" "$0" stop "$Profile" || return $?
+    else
+        ip_unset
+        interface_delete "$Interface"
+    fi
 }
 
 

--- a/src/lib/namespace
+++ b/src/lib/namespace
@@ -1,0 +1,52 @@
+## Add an namespace
+# $1: namespace name
+# $2: interface 
+namespace_add_interface() {
+    local space="$1" interface="$2"
+    if ! namespace_is_exist "$space"; then
+        do_debug ip netns add "$space" || return
+    fi
+
+    ip link set dev "$interface" netns "$space"
+}
+
+
+## Check if a string represents a network namespace
+# $1: potential interface name
+namespace_is_exist() {
+    [[ -f /var/run/netns/$1 ]]
+}
+
+
+## Exec command in namespace
+# $1: namespace
+# $2: command
+# ${@:3}: args
+namespace_exec() {
+    local space="$1" command="$2" args="${@:3}"
+    case "$(type -t $command)" in
+        file|alias)
+            ;;
+        function)
+            command="$(declare -f "$command")"
+            ;;
+    esac
+    ip netns exec "$space" bash -c "$command $args"
+    return $?
+}
+
+
+## Check if a interface in a network namespace
+# $1: namespace name
+# $2: interface
+namespace_contain_interface() {
+    local namespace="$1" interface="$2"
+    namespace_exec "$namespace" test -d "/sys/class/net/${interface%%:?*}"
+}
+
+
+## Check is in namespace
+# $1: namespace
+is_in_namespace() {
+    [[ -n "$1" ]] && [[ "$(ip netns identify $$)" = "$1" ]]
+}


### PR DESCRIPTION
Wireguard document [here](https://www.wireguard.com/netns/)

So I add a new configure option 'WGNamespace', if exist, the wireguard will be moved into the sub interface

Here is my test environment, built by GNS3, with archlinux qemu vm, base-1 and base-2 are peers

![img1](https://github.com/joukewitteveen/netctl/assets/73207484/db5799f1-d020-4aae-8ac6-af6fbb3b0ee6)

Configure origin
![img2](https://github.com/joukewitteveen/netctl/assets/73207484/d902a429-7133-4c46-9160-f26e9c8705d2)

Configure with 'WGNamespace=subnet'
![img3](https://github.com/joukewitteveen/netctl/assets/73207484/2daf2d82-8c53-4959-be52-aa33dc1e6f0c)
